### PR TITLE
Remove ventana and expose engine API

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+    "files.exclude": {
+        "**/build_tmp": true,
+        "**/exports": true,
+        "**/tmp": true,
+        "**/node_modules": true,
+        "**/.git": true,
+        "**/.svn": true,
+        "**/.hg": true,
+        "**/.DS_Store": true
+    }
+,
+"typescript.tsdk": "./node_modules/typescript/lib"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,10 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "0.1.0",
+    "command": "tsc",
+    "isShellCommand": true,
+    "args": ["-p", "."],
+    "showOutput": "silent",
+    "problemMatcher": "$tsc"
+}

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -6,12 +6,54 @@ Unless required by applicable law or agreed to in writing, software  distribut
 
 var Funnel = require('broccoli-funnel');
 var uglify = require('broccoli-uglify-js');
+var typescript = require('broccoli-typescript-compiler').typescript;
+var Rollup = require('broccoli-rollup');
+var merge = require('broccoli-merge-trees');
+var replace = require('broccoli-string-replace');
 
-var tree = new Funnel('build_tmp', {
-  include: ['spaniel.js']
+var es6Tree = typescript('src', {
+  tsconfig: {
+    compilerOptions: {
+      "noImplicitAny": true,
+      "declaration": true,
+      "isolatedModules": false,
+      "module": "es2015",
+      "target": "es5",
+      "outDir": "es6",
+      "sourceMap": true,
+      "moduleResolution": "node"
+    },
+    filesGlob: [
+      "**/*.ts"
+    ]
+  }
 });
 
-module.exports = uglify(tree, {
+// use replace to fix ES6 + Typescript helpers issue
+// Possibly won't be needed after https://github.com/Microsoft/TypeScript/pull/9097
+var umdTree = replace(new Rollup(es6Tree, {
+  rollup: {
+    entry: 'es6/index.js',
+    dest: 'spaniel.js',
+    format: 'umd',
+    moduleName: 'spaniel',
+    exports: 'named',
+    sourceMap: true,
+  }
+}), {
+  files: [ 'spaniel.js' ],
+  pattern: {
+    match: /undefined.__extends/g,
+    replacement: 'false'
+  }
+});
+
+
+var minTree = uglify(new Funnel(umdTree, {
+  destDir: 'min'
+}), {
   mangle: true,
   compress: true
 });
+
+module.exports = merge([es6Tree, umdTree, minTree]);

--- a/README.md
+++ b/README.md
@@ -111,9 +111,45 @@ There are four different event types passed to the watcher callback:
 * `impressed` - When the DOM element has been visible for the configured amount of time.
 * `impression-complete` - When an impressed element is no longer impressed. This event includes the total duration of time the element was visible.
 
-## How it works
+## Utility API
 
-Under the hood, Spaniel uses [Ventana](https://www.github.com/asakusuma/ventana/), a `requestAnmiationFrame`-based stream and window utility. Spaniel does not use mutation observers, scroll listeners, or resize listeners. Instead, `requestAnmiationFrame` polling is used for performance reasons.
+Under the hood, Spaniel uses `requestAnmiationFrame` to preform microtask scheduling. Spaniel does not use mutation observers, scroll listeners, or resize listeners. Instead, `requestAnmiationFrame` polling is used for performance reasons.
+
+Spaniel exposes an API for hooking into the built-in `requestAnmiationFrame` task scheduling engine, or even setting your own `requestAnmiationFrame` task scheduling engine.
+
+```JavaScript
+import { on, off, scheduleRead, scheduleWrite } from 'spaniel';
+
+// Do something on scroll
+on('scroll', (frame) => {
+  console.log('I scrolled to ' + frame.scrollTop);
+});
+
+function onResize(frame) {
+  console.log('Viewport is ' + frame.width + 'px wide');
+}
+
+// Do something on window resize
+on('resize', onResize);
+
+// Stop watching resize
+off('resize', onResize);
+
+// Triggered after all spaniel observer callbacks have fired during `unload`
+on('destroy', flushBeacons);
+
+// Proxy to visibilitychange API
+on('show', onTabFocus);
+on('hide', onTabUnfocus);
+
+scheduleRead(() => {
+  console.log('This will get executed during the DOM read phase of the rAF loop');
+});
+
+scheduleWrite(() => {
+  console.log('This will get executed during the write/mutation phase of the rAF loop');
+});
+```
 
 #### How is it tested?
 

--- a/build.sh
+++ b/build.sh
@@ -4,14 +4,5 @@
 
 rm -rf exports
 ./node_modules/tslint/bin/tslint src/**/*.ts &&
-tsc &&
-tsc -m es2015 -t es6 --outDir build_tmp/es6 &&
-browserify -p browserify-derequire build_tmp/cjs/index.js -s spaniel -o build_tmp/spaniel.js &&
 broccoli build exports &&
-mkdir exports/min &&
-mv exports/spaniel.js exports/min &&
-mv build_tmp/cjs exports &&
-mv build_tmp/es6 exports &&
-mv build_tmp/spaniel.js exports &&
-rollup -c &&
 npm run stats

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1,1 +1,0 @@
-declare module "ventana";

--- a/package.json
+++ b/package.json
@@ -2,18 +2,15 @@
   "name": "spaniel",
   "version": "1.0.0",
   "description": "LinkedIn's viewport tracking library",
-  "license" : "Apache 2.0",
+  "license": "Apache 2.0",
   "main": "exports/spaniel.js",
   "scripts": {
     "test": "npm run build && testem ci && node test/headless/run",
     "serve": "node test/headless/server/app",
-    "watch": "node watch",
+    "watch": "broccoli-timepiece exports",
     "build": "./build.sh",
-    "postinstall": "echo \"npm postinstall noop\"",
     "stats": "node size-calc",
-    "build-docs": "/build_docs.sh",
-    "prepublish": "npm run build",
-    "tsc": "rm -rf exports/cjs && tsc"
+    "prepublish": "npm run build"
   },
   "repository": {
     "type": "git",
@@ -25,11 +22,8 @@
   "author": {
     "name": "Asa Kusuma"
   },
-  "dependencies": {
-    "ventana": "^0.6.1"
-  },
   "homepage": "https://github.com/linkedin/spaniel",
-  "jsnext:main": "exports/es6/spaniel.js",
+  "jsnext:main": "exports/es6/index.js",
   "devDependencies": {
     "assert": "^1.3.0",
     "babel-core": "^6.11.4",
@@ -37,9 +31,11 @@
     "broccoli": "^0.16.9",
     "broccoli-cli": "1.0.0",
     "broccoli-funnel": "^1.0.1",
+    "broccoli-merge-trees": "^1.1.4",
+    "broccoli-rollup": "^1.0.3",
+    "broccoli-string-replace": "^0.1.1",
+    "broccoli-typescript-compiler": "^1.0.1",
     "broccoli-uglify-js": "^0.1.3",
-    "browserify": "^13.0.1",
-    "browserify-derequire": "^0.9.4",
     "chai": "^3.5.0",
     "chokidar": "^1.6.0",
     "express": "^4.13.4",
@@ -54,6 +50,6 @@
     "testem": "^1.12.0",
     "tslint": "^3.6.0",
     "typedoc": "^0.4.2",
-    "typescript": "^2.0.3"
+    "typescript": "^2.0.6"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,9 +2,8 @@ import nodeResolve from 'rollup-plugin-node-resolve';
 
 export default {
   entry: 'exports/es6/index.js',
-  format: 'es',
+  format: 'umd',
   dest: 'exports/es6/spaniel.js',
-  plugins: [
-    nodeResolve({ jsnext: true, main: true })
-  ]
+  exports: 'named',
+  sourceMap: true,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,10 +16,26 @@ import {
   SpanielObserverEntry
 } from './spaniel-observer';
 
+import {
+  setGlobalEngine,
+  getGlobalEngine
+} from './metal/engine';
+
+import {
+  Scheduler,
+  getGlobalScheduler,
+  on,
+  off
+} from './metal/index';
+
 export {
+  on,
+  off,
   IntersectionObserver,
   SpanielObserver,
-  SpanielTrackedElement
+  SpanielTrackedElement,
+  setGlobalEngine,
+  getGlobalEngine
 };
 
 function onEntry(entries: SpanielObserverEntry[]) {
@@ -35,6 +51,10 @@ function onEntry(entries: SpanielObserverEntry[]) {
       });
     }
   });
+}
+
+export function scheduler() {
+  return new Scheduler(getGlobalEngine());
 }
 
 export interface WatcherConfig {
@@ -85,3 +105,4 @@ export class Watcher {
     this.observer.disconnect();
   }
 }
+

--- a/src/metal/element.ts
+++ b/src/metal/element.ts
@@ -1,0 +1,25 @@
+/*
+Copyright 2016 LinkedIn Corp. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ 
+Unless required by applicable law or agreed to in writing, software  distributed under the License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+import {
+  QueueElementInterface,
+  QueueDOMElementInterface,
+  FrameInterface
+} from './interfaces';
+
+class QueueElement implements QueueElementInterface {
+  callback: (frame: FrameInterface, id: string) => void;
+  id: string;
+}
+
+export default QueueElement;
+
+export class QueueDOMElement implements QueueDOMElementInterface {
+  el: Element;
+  callback: (frame: FrameInterface, id: string, bcr: ClientRect) => void;
+  id: string;
+  bcr: ClientRect;
+}

--- a/src/metal/engine.ts
+++ b/src/metal/engine.ts
@@ -1,0 +1,53 @@
+/*
+Copyright 2016 LinkedIn Corp. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ 
+Unless required by applicable law or agreed to in writing, software  distributed under the License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+import { EngineInterface } from './interfaces';
+import W from './window-proxy';
+
+export class Engine implements EngineInterface {
+  private reads: Array<Function> = [];
+  private work: Array<Function> = [];
+  private running: Boolean = false;
+  scheduleRead(callback: Function) {
+    this.reads.unshift(callback);
+    this.run();
+  }
+  scheduleWork(callback: Function) {
+    this.work.unshift(callback);
+    this.run();
+  }
+  private run() {
+    if (!this.running) {
+      this.running = true;
+      W.rAF(() => {
+        this.running = false;
+        for (let i = 0, rlen = this.reads.length; i < rlen; i++) {
+          this.reads.pop()();
+        }
+        for (let i = 0, wlen = this.work.length; i < wlen; i++) {
+          this.work.pop()();
+        }
+        if (this.work.length > 0 || this.reads.length > 0) {
+          this.run();
+        }
+      });
+    }
+  }
+}
+
+let globalEngine: EngineInterface = null;
+
+export function setGlobalEngine(engine: EngineInterface): boolean {
+  if (!!globalEngine) {
+    return false;
+  }
+  globalEngine = engine;
+  return true;
+}
+
+export function getGlobalEngine() {
+  return globalEngine || (globalEngine = new Engine());
+}

--- a/src/metal/events.ts
+++ b/src/metal/events.ts
@@ -1,0 +1,131 @@
+/*
+Copyright 2016 LinkedIn Corp. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ 
+Unless required by applicable law or agreed to in writing, software  distributed under the License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+import {
+  generateToken,
+  Frame,
+  Scheduler,
+  PredicatedScheduler,
+  Queue,
+  FunctionQueue,
+  getGlobalScheduler
+} from './index';
+
+import {
+  FrameInterface
+} from './interfaces';
+
+import w from './window-proxy';
+
+interface EventRecordInterface {
+  listen: (callback: Function) => any;
+  unlisten: (callback: Function) => void;
+  trigger: (value?: any) => void;
+}
+
+class GenericEventRecord {
+  queue: FunctionQueue = new FunctionQueue();
+  listen(callback: (frame: FrameInterface, id: string) => void) {
+    this.queue.push(callback);
+  }
+  unlisten(callback: Function) {
+    this.queue.remove(callback);
+  }
+  trigger(value?: any) {
+    for (let i = 0; i < this.queue.items.length; i++) {
+      this.queue.items[i](value);
+    }
+  }
+}
+
+class RAFEventRecord {
+  private scheduler: PredicatedScheduler;
+  public state: Frame;
+  constructor(predicate: (frame: Frame) => Boolean) {
+    this.scheduler = new PredicatedScheduler(predicate.bind(this));
+  }
+  trigger(value?: any) {}
+  listen(callback: (frame: Frame) => void) {
+    this.state = Frame.generate();
+    this.scheduler.watch(callback);
+  }
+  unlisten(cb: Function) {
+    this.scheduler.unwatch(cb);
+  }
+}
+
+interface EventStore {
+  scroll: RAFEventRecord;
+  resize: RAFEventRecord;
+  destroy: GenericEventRecord;
+  unload: GenericEventRecord;
+  hide: GenericEventRecord;
+  show: GenericEventRecord;
+  [eventName: string]: EventRecordInterface;
+}
+
+let eventStore: EventStore = {
+  scroll: new RAFEventRecord(function(frame: Frame) {
+    let { scrollTop, scrollLeft } = this.state;
+    this.state = frame;
+    return scrollTop !== frame.scrollTop || scrollLeft !== frame.scrollLeft;
+  }),
+  resize: new RAFEventRecord(function(frame: Frame) {
+    let { width, height } = this.state;
+    this.state = frame;
+    return height !== frame.height || width !== frame.width;
+  }),
+  destroy: new GenericEventRecord(),
+  unload: new GenericEventRecord(),
+  hide: new GenericEventRecord(),
+  show: new GenericEventRecord()
+};
+
+if (w.hasDOM) {
+  window.addEventListener('unload', function(e: any) {
+    // First fire internal event to fire any observer callbacks
+    eventStore.unload.trigger();
+
+    // Then fire external event to allow flushing of any beacons
+    eventStore.destroy.trigger();
+  });
+  document.addEventListener('visibilitychange', function onVisibilityChange() {
+    if (document.visibilityState === 'visible') {
+      eventStore.show.trigger();
+    } else {
+      eventStore.hide.trigger();
+    }
+  });
+}
+
+export function on(eventName: string, callback: (frame: FrameInterface, id: string) => void) {
+  let evt = eventStore[eventName];
+  if (evt) {
+    evt.listen(callback);
+  }
+}
+
+export function off(eventName: string, callback: Function) {
+  let evt = eventStore[eventName];
+  if (evt) {
+    evt.unlisten(callback);
+  }
+}
+
+export function trigger(eventName: string, value: any) {
+  let evt = eventStore[eventName];
+  if (evt) {
+    evt.trigger(value);
+  }
+}
+
+export function scheduleWork(callback: Function) {
+  getGlobalScheduler().scheduleWork(callback);
+}
+
+export function scheduleRead(callback: Function) {
+  getGlobalScheduler().scheduleRead(callback);
+}

--- a/src/metal/index.ts
+++ b/src/metal/index.ts
@@ -1,0 +1,49 @@
+/*
+Copyright 2016 LinkedIn Corp. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ 
+Unless required by applicable law or agreed to in writing, software  distributed under the License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+import w from './window-proxy';
+import { default as QueueElement, QueueDOMElement } from './element';
+import { default as Queue, DOMQueue, FunctionQueue } from './queue';
+import { QueueElementInterface, QueueDOMElementInterface, FrameInterface, QueueInterface } from './interfaces';
+import { generateToken, ElementScheduler, Scheduler, PredicatedScheduler, Frame, getGlobalScheduler } from './scheduler';
+import { Engine } from  './engine';
+import { on, off } from  './events';
+
+interface AbsoluteRect {
+  top: number;
+  bottom: number;
+  width: number;
+  height: number;
+}
+
+interface Offset {
+  top: number;
+  left: number;
+  right: number;
+  bottom: number;
+}
+
+export {
+  Offset,
+  FrameInterface,
+  QueueElementInterface,
+  QueueDOMElementInterface,
+  QueueInterface,
+  Queue,
+  DOMQueue,
+  FunctionQueue,
+  QueueElement,
+  QueueDOMElement,
+  ElementScheduler,
+  PredicatedScheduler,
+  Scheduler,
+  Engine,
+  generateToken,
+  Frame,
+  getGlobalScheduler,
+  on,
+  off
+};

--- a/src/metal/interfaces.ts
+++ b/src/metal/interfaces.ts
@@ -1,0 +1,49 @@
+/*
+Copyright 2016 LinkedIn Corp. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ 
+Unless required by applicable law or agreed to in writing, software  distributed under the License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+export interface QueueElementInterface {
+  callback: (frame: FrameInterface, id: string) => void;
+  id: string;
+}
+
+export interface QueueDOMElementInterface {
+  id: string;
+  callback: (frame: FrameInterface, id: string, bcr: ClientRect) => void;
+  el: Element;
+}
+
+export interface QueueInterface {
+  push: (element: QueueElementInterface) => void;
+  isEmpty: () => Boolean;
+  remove: (id: string | Element| Function) => void;
+  clear: () => void;
+}
+
+export interface EngineInterface {
+  scheduleRead: (callback: Function) => void;
+  scheduleWork: (callback: Function) => void;
+}
+
+export interface BaseSchedulerInterface {
+  scheduleRead: (callback: Function) => void;
+  scheduleWork: (callback: Function) => void;
+}
+
+export interface SchedulerInterface extends BaseSchedulerInterface {
+  watch: (callback: (frame: FrameInterface) => void) => string;
+}
+
+export interface ElementSchedulerInterface extends BaseSchedulerInterface {
+  watch: (el: Element, callback: (frame: FrameInterface, id: string, bcr: ClientRect) => void, id?: string) => string;
+}
+
+export interface FrameInterface {
+  timestamp: number;
+  scrollTop: number;
+  scrollLeft: number;
+  width: number;
+  height: number;
+}

--- a/src/metal/queue.ts
+++ b/src/metal/queue.ts
@@ -1,0 +1,74 @@
+/*
+Copyright 2016 LinkedIn Corp. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ 
+Unless required by applicable law or agreed to in writing, software  distributed under the License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+import {
+  QueueInterface,
+  QueueElementInterface,
+  QueueDOMElementInterface
+} from './interfaces';
+
+export abstract class BaseQueue implements QueueInterface {
+  protected items: Array<any>;
+  constructor() {
+    this.items = [];
+  }
+
+  abstract removePredicate(identifier: any, element: any): void;
+
+  remove(identifier: string | Element | Function) {
+    let len = this.items.length;
+    for (let i = 0; i < len; i++) {
+      if (this.removePredicate(identifier, this.items[i])) {
+        this.items.splice(i, 1);
+        i--;
+        len--;
+      }
+    }
+  }
+
+  clear() {
+    this.items = [];
+  }
+
+  push(element: any) {
+    this.items.push(element);
+  }
+
+  isEmpty() {
+    return this.items.length === 0;
+  }
+}
+
+export default class Queue extends BaseQueue implements QueueInterface {
+  items: Array<QueueElementInterface>;
+  removePredicate(identifier: string, element: QueueElementInterface) {
+    if (typeof identifier === 'string') {
+      return element.id === identifier;
+    } else {
+      return element.callback === identifier;
+    }
+  }
+}
+
+export class FunctionQueue extends BaseQueue implements QueueInterface {
+  items: Array<Function>;
+  removePredicate(identifier: Function, element: Function) {
+    return element === identifier;
+  }
+}
+
+export class DOMQueue extends BaseQueue implements QueueInterface {
+  items: Array<QueueDOMElementInterface>;
+  removePredicate(identifier: Element | string | Function, element: QueueDOMElementInterface) {
+    if (typeof identifier === 'string') {
+      return element.id === identifier;
+    } else if (typeof identifier === 'function') {
+      return element.callback === identifier;
+    } else {
+      return element.el === identifier;
+    }
+  }
+}

--- a/src/metal/scheduler.ts
+++ b/src/metal/scheduler.ts
@@ -1,0 +1,151 @@
+/*
+Copyright 2016 LinkedIn Corp. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ 
+Unless required by applicable law or agreed to in writing, software  distributed under the License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+import {
+  EngineInterface,
+  SchedulerInterface,
+  ElementSchedulerInterface,
+  FrameInterface,
+  QueueInterface
+} from './interfaces';
+import W from './window-proxy';
+
+import { default as Queue, DOMQueue} from './queue';
+import { getGlobalEngine } from './engine';
+
+const TOKEN_SEED = 'xxxx'.replace(/[xy]/g, function(c) {
+  let r = Math.random() * 16 | 0, v = c === 'x' ? r : (r & 0x3 | 0x8);
+  return v.toString(16);
+});
+let tokenCounter = 0;
+
+export class Frame implements FrameInterface {
+  constructor(
+    public timestamp: number,
+    public scrollTop: number,
+    public scrollLeft: number,
+    public width: number,
+    public height: number
+  ) {}
+  static generate(): Frame {
+    return new Frame(
+      Date.now(),
+      W.getScrollTop(),
+      W.getScrollLeft(),
+      W.getWidth(),
+      W.getHeight()
+    );
+  }
+}
+
+export function generateToken() {
+  return tokenCounter++ + TOKEN_SEED;
+}
+
+export abstract class BaseScheduler {
+  protected engine: EngineInterface;
+  protected queue: QueueInterface;
+  protected isTicking: Boolean = false;
+  constructor(customEngine?: EngineInterface) {
+    if (customEngine) {
+      this.engine = customEngine;
+    } else {
+      this.engine = getGlobalEngine();
+    }
+  }
+  protected abstract applyQueue(frame: Frame): void;
+
+  protected tick() {
+    if (this.queue.isEmpty()) {
+      this.isTicking = false;
+    } else {
+      let frame = Frame.generate();
+      this.applyQueue(frame);
+      this.engine.scheduleRead(this.tick.bind(this));
+    }
+  }
+  scheduleWork(callback: Function) {
+    this.engine.scheduleWork(callback);
+  }
+  scheduleRead(callback: Function) {
+    this.engine.scheduleRead(callback);
+  }
+  unwatch(id: string| Element | Function) {
+    this.queue.remove(id);
+  }
+  unwatchAll() {
+    this.queue.clear();
+  }
+  startTicking() {
+    if (!this.isTicking) {
+      this.isTicking = true;
+      this.engine.scheduleRead(this.tick.bind(this));
+    }
+  }
+}
+
+export class Scheduler extends BaseScheduler implements SchedulerInterface {
+  protected queue: Queue = new Queue();
+  applyQueue(frame: Frame) {
+    for (let i = 0; i < this.queue.items.length; i++) {
+      let { id, callback } = this.queue.items[i];
+      callback(frame, id);
+    }
+  }
+  watch(callback: (frame: FrameInterface) => void): string {
+    this.startTicking();
+    let id = generateToken();
+    this.queue.push({
+      callback,
+      id
+    });
+    return id;
+  }
+}
+
+export class PredicatedScheduler extends Scheduler implements SchedulerInterface {
+  predicate: (frame: Frame) => Boolean;
+  constructor(predicate: (frame: Frame) => Boolean) {
+    super(null);
+    this.predicate = predicate;
+  }
+  applyQueue(frame: Frame) {
+    if (this.predicate(frame)) {
+      super.applyQueue(frame);
+    }
+  }
+}
+
+export class ElementScheduler extends BaseScheduler implements ElementSchedulerInterface {
+  protected queue: DOMQueue;
+  constructor(customEngine?: EngineInterface) {
+    super(customEngine);
+    this.queue = new DOMQueue();
+  }
+  applyQueue(frame: Frame) {
+    for (let i = 0; i < this.queue.items.length; i++) {
+      let { callback, el, id } = this.queue.items[i];
+      let bcr = el.getBoundingClientRect();
+      callback(frame, id, bcr);
+    }
+  }
+  watch(el: Element, callback: (frame: FrameInterface, id: string, bcr: ClientRect) => void, id?: string): string {
+    this.startTicking();
+    id = id || generateToken();
+    this.queue.push({
+      el,
+      callback,
+      id
+    });
+    return id;
+  }
+}
+
+let globalScheduler: Scheduler = new Scheduler();
+
+export function getGlobalScheduler() {
+  return globalScheduler;
+}

--- a/src/metal/window-proxy.ts
+++ b/src/metal/window-proxy.ts
@@ -1,0 +1,50 @@
+/*
+Copyright 2016 LinkedIn Corp. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ 
+Unless required by applicable law or agreed to in writing, software  distributed under the License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+// detect the presence of DOM
+const nop = () => 0;
+
+interface WindowProxy {
+  hasDOM: boolean;
+  getScrollTop: Function;
+  getScrollLeft: Function;
+  getHeight: Function;
+  getWidth: Function;
+  rAF: Function;
+}
+
+let hasDOM = !!((typeof window !== 'undefined') && window && (typeof document !== 'undefined') && document);
+
+let W: WindowProxy = {
+  hasDOM,
+  getScrollTop: nop,
+  getScrollLeft: nop,
+  getHeight: nop,
+  getWidth: nop,
+  rAF: hasDOM && !!window.requestAnimationFrame ? window.requestAnimationFrame.bind(window) : () => {}
+};
+
+function hasDomSetup() {
+  let se = typeof (<any>document).scrollingElement !== 'undefined';
+  W.getScrollTop = se ? () => (<any>document).scrollingElement.scrollTop : () => (<any>window).scrollY;
+  W.getScrollLeft = se ? () => (<any>document).scrollingElement.scrollLeft : () => (<any>window).scrollX;
+  W.getHeight = () => (<any>window).innerHeight;
+  W.getWidth = () => (<any>window).innerWidth;
+}
+
+if (hasDOM) {
+  if ((<any>document).readyState !== 'loading') {
+    hasDomSetup();
+  } else {
+    (<any>document).addEventListener('DOMContentLoaded', hasDomSetup);
+  }
+}
+
+export {
+  WindowProxy
+};
+
+export default W;

--- a/test/headless/run.js
+++ b/test/headless/run.js
@@ -13,6 +13,7 @@ server.stdout.on('data', (data) => {
   // Wait for signal that test app has booted
   if (data.indexOf('Serving Spaniel Test App') > -1 && !test) {
     test = spawn('./node_modules/mocha/bin/mocha', ['--compilers', 'js:babel-core/register', 'test/headless/specs/**/*.js']);
+    //mocha --compilers js:babel-core/register test/headless/specs/**/*.js
 
     test.stderr.on('data', (data) => {
       console.log(`Test Error: ${data}`);

--- a/test/headless/specs/events.js
+++ b/test/headless/specs/events.js
@@ -1,0 +1,74 @@
+/*
+Copyright 2016 LinkedIn Corp. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+import { assert } from 'chai';
+import {
+  default as testModule,
+  TestClass
+} from './../test-module';
+
+testModule('on()', class extends TestClass {
+  ['@test scroll event callback fires']() {
+    return this.context.evaluate(function() {
+      window.STATE.scrollEvents = 0;
+      spaniel.on('scroll', function() {
+        window.STATE.scrollEvents++;
+      });
+    })
+    .scrollTo(10)
+    .wait(10)
+    .getExecution()
+    .evaluate(function() {
+      return window.STATE.scrollEvents;
+    }).then(function(result) {
+      assert.equal(result, 1, 'Callback fired once');
+    });
+  }
+
+  ['@test scroll event callback fires twice with two scrolls']() {
+    return this.context.evaluate(function() {
+      window.STATE.scrollEvents = 0;
+      spaniel.on('scroll', function() {
+        window.STATE.scrollEvents++;
+      });
+    })
+    .scrollTo(10)
+    .wait(10)
+    .scrollTo(20)
+    .wait(10)
+    .getExecution()
+    .evaluate(function() {
+      return window.STATE.scrollEvents;
+    }).then(function(result) {
+      assert.equal(result, 2, 'Callback fired twice');
+    });
+  }
+
+  ['@test scroll event callback can be unbound']() {
+    return this.context.evaluate(function() {
+      window.STATE.scrollEvents = 0;
+      window.STATE.scrollHandler = function() {
+        window.STATE.scrollEvents++;
+      };
+      spaniel.on('scroll',  window.STATE.scrollHandler);
+    })
+    .scrollTo(10)
+    .wait(10)
+    .evaluate(function() {
+      spaniel.off('scroll', window.STATE.scrollHandler);;
+    })
+    .scrollTo(20)
+    .wait(10)
+    .scrollTo(30)
+    .wait(10)
+    .getExecution()
+    .evaluate(function() {
+      return window.STATE.scrollEvents;
+    }).then(function(result) {
+      assert.equal(result, 1, 'Callback fired once');
+    });
+  }
+});

--- a/test/headless/specs/intersection-observer.js
+++ b/test/headless/specs/intersection-observer.js
@@ -196,4 +196,38 @@ testModule('IntersectionObserver', class extends TestClass {
       assert.equal(result, 3, 'Callback fired 3 times');
     });
   }
+
+  ['@test can restart observing after disconnect']() {
+    return this.context.evaluate(function() {
+      window.STATE.impressions = 0;
+      target1 = document.querySelector('.tracked-item[data-id="1"]');
+      target2 = document.querySelector('.tracked-item[data-id="2"]');
+      target3 = document.querySelector('.tracked-item[data-id="3"]');
+      window.observer = new spaniel.IntersectionObserver(function() {
+        window.STATE.impressions++;
+      });
+      window.observer.observe(target1);
+      window.observer.observe(target2);
+      window.observer.observe(target3);
+    })
+    .wait(50)
+    .evaluate(function() {
+      window.observer.disconnect();
+    })
+    .wait(50)
+    .evaluate(function() {
+      window.observer.observe(document.querySelector('.tracked-item[data-id="1"]'));
+    })
+    .wait(50)
+    .scrollTo(500)
+    .wait(50)
+    .scrollTo(0)
+    .wait(50)
+    .getExecution()
+    .evaluate(function() {
+      return window.STATE.impressions;
+    }).then(function(result) {
+      assert.equal(result, 6, 'Callback fired 6 times');
+    });
+  }
 });

--- a/test/headless/specs/watcher/impression-event.spec.js
+++ b/test/headless/specs/watcher/impression-event.spec.js
@@ -30,8 +30,6 @@ testModule('Impression event', class extends WatcherTestClass {
       .wait(5)
       .scrollTo(250)
       .wait(5)
-      .scrollTo(200)
-      .wait(5)
       .scrollTo(0)
       .wait(5)
       .assertNever(5, 'impressed').done();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,28 +1,6 @@
 {
-	"compilerOptions": {
-		"noImplicitAny": true,
-		"declaration": true,
-		"isolatedModules": false,
-		"module": "commonjs",
-		"target": "es5",
-		"outDir": "build_tmp/cjs",
-		"sourceMap": true,
-		"moduleResolution": "node"
-	},
-	"exclude": [
-		"node_modules",
-		"exports",
-		"build_tmp"
-	],
-	"filesGlob": [
-		"src/**/*.ts"
-	],
-	"files": [
-		"src/index.ts",
-		"src/intersection-observer.ts",
-		"src/spaniel-observer.ts"
-	],
-	"atom": {
-		"rewriteTsconfig": true
-	}
+    "compilerOptions": {
+        "watch": true,
+        "outDir": "exports/tsc"
+    }
 }

--- a/watch.js
+++ b/watch.js
@@ -1,19 +1,0 @@
-/*
-Copyright 2016 LinkedIn Corp. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-*/
-
-var chokidar = require('chokidar');
-var exec = require('child_process').exec;
-
-console.log('Watching ./src files...');
-
-chokidar.watch('./src', {ignored: /[\/\\]\./}).on('all', (event, path) => {
-  if (event === 'change') {
-    console.log(path + 'changed. Rebuilding...');
-    exec('./build.sh', function (error, stdout, stderr) {
-      console.log('Done rebuilding!');
-    });
-  }
-});


### PR DESCRIPTION
 Exposes API for setting an external global engine:
- [Interface](https://github.com/linkedin/spaniel/blob/engine-refactor/src/engine/interfaces.ts#L22)
- [API](https://github.com/linkedin/spaniel/blob/engine-refactor/src/global-engine.ts#L14)

Next step is to improve the public API for scheduling work and watching window events

cc @runspired @chadhietala @krisselden 