### PR TITLE
Fix Window Height/Width Availability Race Condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,14 @@ Alternatively, running *npm run build* will generate a UMD file at `/exports/spa
 ## Development setup
 The Spaniel source code is written in [TypeScript](https://www.typescriptlang.org/).
 
+You will need `testem` installed globally to run the tests.
+
+```
+npm install -g testem
+```
+
+You will also need to install [phantom.js](http://phantomjs.org/download.html) globally.
+
 ```
 // Install dependencies
 npm install

--- a/src/metal/window-proxy.ts
+++ b/src/metal/window-proxy.ts
@@ -1,6 +1,6 @@
 /*
 Copyright 2016 LinkedIn Corp. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- 
+
 Unless required by applicable law or agreed to in writing, software  distributed under the License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 
@@ -31,11 +31,13 @@ function hasDomSetup() {
   let se = typeof (<any>document).scrollingElement !== 'undefined';
   W.getScrollTop = se ? () => (<any>document).scrollingElement.scrollTop : () => (<any>window).scrollY;
   W.getScrollLeft = se ? () => (<any>document).scrollingElement.scrollLeft : () => (<any>window).scrollX;
-  W.getHeight = () => (<any>window).innerHeight;
-  W.getWidth = () => (<any>window).innerWidth;
 }
 
 if (hasDOM) {
+  // Set the height and width immediately because they will be available at this point
+  W.getHeight = () => (<any>window).innerHeight;
+  W.getWidth = () => (<any>window).innerWidth;
+
   if ((<any>document).readyState !== 'loading') {
     hasDomSetup();
   } else {


### PR DESCRIPTION
The `DOMContentLoaded` event was being fired late in bigpipe mode.
This resulted in the height/width being set to 0.  Moved setting
the window height/width before waiting for `DOMContentLoaded`