### PR TITLE
Schedule IntersectionObserver callbacks on work queue

### DIFF
--- a/src/intersection-observer.ts
+++ b/src/intersection-observer.ts
@@ -112,7 +112,9 @@ export class IntersectionObserver {
 
     if (numSatisfiedThresholds !== record.numSatisfiedThresholds) {
       record.numSatisfiedThresholds = numSatisfiedThresholds;
-      this.callback([entry]);
+      this.scheduler.scheduleWork(() => {
+        this.callback([entry]);
+      });
     }
   }
   unobserve(target: SpanielTrackedElement) {


### PR DESCRIPTION
This is going to create another function and context object allocation per `IntersectionObserver` callback invocation.