### PR TITLE
Fall back when document.scrollingElement is null.

### DIFF
--- a/src/metal/window-proxy.ts
+++ b/src/metal/window-proxy.ts
@@ -28,7 +28,7 @@ let W: WindowProxy = {
 };
 
 function hasDomSetup() {
-  let se = typeof (<any>document).scrollingElement !== 'undefined';
+  let se = (<any>document).scrollingElement != null;
   W.getScrollTop = se ? () => (<any>document).scrollingElement.scrollTop : () => (<any>window).scrollY;
   W.getScrollLeft = se ? () => (<any>document).scrollingElement.scrollLeft : () => (<any>window).scrollX;
 }


### PR DESCRIPTION
In Chrome versions less than 44, document.scrollingElement is null
instead of undefined. In this case, we shouldn't attempt to access
properties off of that object.