### PR TITLE
Attempt to resolve race condition.

### DIFF
--- a/src/spaniel-observer.ts
+++ b/src/spaniel-observer.ts
@@ -224,9 +224,16 @@ export class SpanielObserver {
     }
   }
   disconnect() {
+    // We need to pause the system from ticking when we are disconnecting, because a tick during
+    // disconnecting can cause an entry to be incorrectly queued after flushing the queue.
+    this.paused = true;
+
     this.setAllHidden();
     this.observer.disconnect();
     this.recordStore = {};
+
+    // Now that disconnecting is complete, we can resume ticks.
+    this.paused = false;
   }
   unobserve(element: SpanielTrackedElement) {
     let record = this.recordStore[element.__spanielId];


### PR DESCRIPTION
This is a best effort to resolve what seems to be a race condition
causing callbacks to be queued during disconnecting that run after
disconnecting completes, which should never happen.

To be more specific, I believe what is happening is the following:

1. Disconnect on the SpanielObserver is requested.
2. setAllHidden is called, which will one-by-one for each element queue up any final callbacks to be called and clears any timers that would call callbacks.
3. In the meantime, the scheduler is still ticking and could schedule a new timer for a callback.
4. Finally, disconnect is called on the IntersectionObserver, which immediately stops ticking from doing anything in the future.

Step 3 is where the race condition happens. I think that pausing during disconnecting will resolve this, because each tick will check if the observer is paused before scheduling any callbacks. Please review carefully, as I don't know of a good way to validate this except for trying this out.