### PR TITLE
Improve exported types for TypeScript consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "homepage": "https://github.com/linkedin/spaniel",
   "jsnext:main": "exports/es6/index.js",
+  "typings": "exports/es6/index.d.ts",
   "devDependencies": {
     "assert": "^1.3.0",
     "babel-core": "^6.11.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ Unless required by applicable law or agreed to in writing, software  distribut
 
 import {
   IntersectionObserver,
+  IntersectionObserverEntry,
   DOMString,
   DOMMargin,
   SpanielTrackedElement,
@@ -39,6 +40,7 @@ export {
   scheduleRead,
   scheduleWork,
   IntersectionObserver,
+  IntersectionObserverEntry,
   SpanielObserver,
   SpanielTrackedElement,
   setGlobalEngine,
@@ -112,7 +114,7 @@ export class Watcher {
    });
   }
   watch(el: Element, callback: Function) {
-    this.observer.observe(<SpanielTrackedElement>el, {
+    this.observer.observe(el, {
       callback
     });
   }

--- a/src/intersection-observer.ts
+++ b/src/intersection-observer.ts
@@ -96,11 +96,14 @@ export class IntersectionObserver {
       this.records[keys[i]].numSatisfiedThresholds = 0;
     }
   }
-  observe(target: SpanielTrackedElement) {
-    let id = target.__spanielId = target.__spanielId || generateToken();
+  observe(target: Element) {
+    let trackedTarget = target as SpanielTrackedElement;
+
+    let id = trackedTarget.__spanielId = trackedTarget.__spanielId || generateToken();
+
     this.scheduler.watch(target, (frame: Frame, id: string, bcr: ClientRect) => {
-      this.onTick(frame, id, bcr, target);
-    }, target.__spanielId);
+      this.onTick(frame, id, bcr, trackedTarget);
+    }, trackedTarget.__spanielId);
     return id;
   }
   private onTick(frame: Frame, id: string,  bcr: ClientRect, el: Element) {

--- a/src/spaniel-observer.ts
+++ b/src/spaniel-observer.ts
@@ -239,10 +239,12 @@ export class SpanielObserver {
       })
     }
   }
-  observe(target: SpanielTrackedElement, payload: any = null) {
-    let id = target.__spanielId = target.__spanielId || generateToken();
+  observe(target: Element, payload: any = null) {
+    let trackedTarget = target as SpanielTrackedElement;
+    let id = trackedTarget.__spanielId = trackedTarget.__spanielId || generateToken();
+
     this.recordStore[id] = {
-      target,
+      target: trackedTarget,
       payload,
       lastSeenEntry: null,
       thresholdStates: this.thresholds.map((threshold: SpanielThreshold) => ({
@@ -253,7 +255,7 @@ export class SpanielObserver {
         lastVisible: null
       }))
     };
-    this.observer.observe(target);
+    this.observer.observe(trackedTarget);
     return id;
   }
 }


### PR DESCRIPTION
When using Spaniel from a TypeScript project, we should expose types automatically. This is achieved by setting `typings` in the `package.json`.

I also improved a couple things for consumers:

- `observe` takes an `Element` rather than a `SpanielTrackedElement` for all the observers, not only for `Watcher`.
- We export the `IntersectionObserverEntry` type so consumers can properly type their callbacks.

Thanks for the awesome library!