### PR TITLE
Scheduling work when rAF doesn't exit should still work

### DIFF
--- a/src/metal/window-proxy.ts
+++ b/src/metal/window-proxy.ts
@@ -24,7 +24,7 @@ let W: WindowProxy = {
   getScrollLeft: nop,
   getHeight: nop,
   getWidth: nop,
-  rAF: hasDOM && !!window.requestAnimationFrame ? window.requestAnimationFrame.bind(window) : () => {}
+  rAF: hasDOM && !!window.requestAnimationFrame ? window.requestAnimationFrame.bind(window) : (callback) => { callback(); }
 };
 
 function hasDomSetup() {


### PR DESCRIPTION
Addresses memory leak in headless environments