### PR TITLE
Create independent watcher and spaniel observer versions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,9 +11,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 import {
   SpanielIntersectionObserver,
-  entrySatisfiesRatio,
   generateEntry
 } from './intersection-observer';
+
+import {
+  entrySatisfiesRatio
+} from './utils';
 
 import {
   SpanielTrackedElement,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -57,6 +57,10 @@ export interface SpanielObserverEntry extends IntersectionObserverEntryInit {
   payload?: any;
 }
 
+export interface IntersectionObserverClass {
+  new (callback: IntersectionObserverCallback, options?: IntersectionObserverInit): IntersectionObserver;
+}
+
 export interface SpanielObserverInterface {
   disconnect: () => void;
   unobserve: (element: SpanielTrackedElement) => void;

--- a/src/intersection-observer.ts
+++ b/src/intersection-observer.ts
@@ -10,6 +10,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 
 import {
+  entrySatisfiesRatio
+} from './utils';
+
+import {
   Frame,
   QueueDOMElementInterface,
   DOMQueue,
@@ -174,21 +178,6 @@ export class IntersectionObserverEntry implements IntersectionObserverEntryInit 
   }
 };
 */
-
-export function entrySatisfiesRatio(entry: IntersectionObserverEntry, threshold: number) {
-  let { boundingClientRect, intersectionRatio } = entry;
-
-  // Edge case where item has no actual area
-  if (boundingClientRect.width === 0 || boundingClientRect.height === 0) {
-    let { boundingClientRect, intersectionRect } = entry;
-    return boundingClientRect.left === intersectionRect.left &&
-      boundingClientRect.top === intersectionRect.top &&
-      intersectionRect.width >= 0 &&
-      intersectionRect.height >= 0;
-  } else {
-    return intersectionRatio > threshold || (intersectionRatio === 1 && threshold === 1);
-  }
-}
 
 export function generateEntry(frame: Frame, bcr: DOMRectReadOnly, el: Element, rootMargin: DOMMargin): IntersectionObserverEntry {
   let { top, bottom, left, right } = bcr;

--- a/src/native-spaniel-observer.ts
+++ b/src/native-spaniel-observer.ts
@@ -14,10 +14,6 @@ import {
 } from './utils';
 
 import {
-  SpanielIntersectionObserver
-} from './intersection-observer';
-
-import {
   IntersectionObserverInit,
   DOMString,
   DOMMargin,
@@ -27,7 +23,8 @@ import {
   SpanielRecord,
   SpanielThresholdState,
   SpanielObserverEntry,
-  SpanielTrackedElement
+  SpanielTrackedElement,
+  IntersectionObserverClass
 } from './interfaces';
 
 import w from './metal/window-proxy';
@@ -47,7 +44,7 @@ export class SpanielObserver implements SpanielObserverInterface {
   recordStore: { [key: string]: SpanielRecord; };
   queuedEntries: SpanielObserverEntry[];
   private paused: boolean;
-  constructor(callback: (entries: SpanielObserverEntry[]) => void, options: SpanielObserverInit = {}) {
+  constructor(ObserverClass: IntersectionObserverClass, callback: (entries: SpanielObserverEntry[]) => void, options: SpanielObserverInit = {}) {
     this.paused = false;
     this.queuedEntries = [];
     this.recordStore = {};
@@ -62,7 +59,7 @@ export class SpanielObserver implements SpanielObserverInterface {
       rootMargin: convertedRootMargin,
       threshold: this.thresholds.map((t: SpanielThreshold) => t.ratio)
     };
-    this.observer = new SpanielIntersectionObserver((records: IntersectionObserverEntry[]) => this.internalCallback(records), o);
+    this.observer = new ObserverClass((records: IntersectionObserverEntry[]) => this.internalCallback(records), o);
 
     if (w.hasDOM) {
       on('unload', this.onWindowClosed.bind(this));

--- a/src/native-watcher.ts
+++ b/src/native-watcher.ts
@@ -1,0 +1,90 @@
+/*
+Copyright 2016 LinkedIn Corp. Licensed under the Apache License,
+Version 2.0 (the "License"); you may not use this file except in
+compliance with the License. You may obtain a copy of the License
+at http://www.apache.org/licenses/LICENSE-2.0
+ 
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+import {
+  SpanielObserver
+} from './native-spaniel-observer';
+
+import {
+  SpanielObserverEntry,
+  DOMString,
+  DOMMargin,
+  SpanielTrackedElement,
+  IntersectionObserverClass
+} from './interfaces';
+
+export interface WatcherConfig {
+  ratio?: number;
+  time?: number;
+  rootMargin?: DOMString | DOMMargin;
+}
+
+function onEntry(entries: SpanielObserverEntry[]) {
+  entries.forEach((entry: SpanielObserverEntry) => {
+    if (entry.entering) {
+      entry.payload.callback(entry.label, {
+        duration: entry.duration
+      });
+    } else if (entry.label === 'impressed') {
+      entry.payload.callback('impression-complete', {
+        duration: entry.duration,
+        visibleTime: entry.time - entry.duration
+      });
+    }
+  });
+}
+
+export class Watcher {
+  observer: SpanielObserver;
+  constructor(ObserverClass: IntersectionObserverClass, config: WatcherConfig = {}) {
+    let { time, ratio, rootMargin } = config;
+
+    let threshold = [
+      {
+        label: 'exposed',
+        time: 0,
+        ratio: 0
+      }
+    ];
+
+    if (time) {
+      threshold.push({
+        label: 'impressed',
+        time,
+        ratio: ratio || 0
+      });
+    }
+    
+    if (ratio) {
+      threshold.push({
+        label: 'visible',
+        time: 0,
+        ratio
+      });
+    }
+
+    this.observer = new SpanielObserver(ObserverClass, onEntry, {
+      rootMargin,
+      threshold
+   });
+  }
+  watch(el: Element, callback: Function) {
+    this.observer.observe(el, {
+      callback
+    });
+  }
+  unwatch(el: SpanielTrackedElement) {
+    this.observer.unobserve(el);
+  }
+  disconnect() {
+    this.observer.disconnect();
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,14 @@
+export function entrySatisfiesRatio(entry: IntersectionObserverEntry, threshold: number) {
+  let { boundingClientRect, intersectionRatio } = entry;
+
+  // Edge case where item has no actual area
+  if (boundingClientRect.width === 0 || boundingClientRect.height === 0) {
+    let { boundingClientRect, intersectionRect } = entry;
+    return boundingClientRect.left === intersectionRect.left &&
+      boundingClientRect.top === intersectionRect.top &&
+      intersectionRect.width >= 0 &&
+      intersectionRect.height >= 0;
+  } else {
+    return intersectionRatio > threshold || (intersectionRatio === 1 && threshold === 1);
+  }
+}


### PR DESCRIPTION
Create “native” versions of watcher and spaniel observer that don’t
depend directly on the intersection observer polypill. Changes the API
and requires passing in an intersection observer class, i.e. dependency
injection. This doesn’t affect the public API, just adding for
experimentation for now.