### PR TITLE
Add SpanielObserver.destroy()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # spaniel Changelog
 
+### 3.1.0 (July 27, 2017)
+
+* Add `SpanielObserver.destroy()` to cleanup memory.
+
 ### 3.0.0 (July 27, 2017)
 
 * Fix `rootMargin` [sign bug](https://github.com/linkedin/spaniel/issues/24). Positive `rootMargin` values should expand the offset. This is a breaking change for anyone currently setting `rootMargin`.

--- a/USAGE.md
+++ b/USAGE.md
@@ -72,6 +72,9 @@ let target = document.getElementById('my-element');
 observer.observe(target, {
   name: 'My Element'
 });
+
+// Cleanup when done to prevent memory leaks.
+observer.destroy();
 ```
 
 ### spaniel.Watcher

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spaniel",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "LinkedIn's viewport tracking library",
   "license": "Apache 2.0",
   "main": "exports/spaniel.js",

--- a/src/spaniel-observer.ts
+++ b/src/spaniel-observer.ts
@@ -32,7 +32,13 @@ import {
 
 import w from './metal/window-proxy';
 
-import { generateToken, on, scheduleWork } from './metal/index';
+import {
+  FrameInterface,
+  generateToken,
+  on,
+  off,
+  scheduleWork
+} from './metal/index';
 
 let emptyRect = { x: 0, y: 0, width: 0, height: 0 };
 
@@ -49,6 +55,9 @@ export class SpanielObserver implements SpanielObserverInterface {
   recordStore: { [key: string]: SpanielRecord; };
   queuedEntries: SpanielObserverEntry[];
   private paused: boolean;
+  private onWindowClosed: () => void;
+  private onTabHidden: () => void;
+  private onTabShown: () => void;
   constructor(callback: (entries: SpanielObserverEntry[]) => void, options: SpanielObserverInit = {}) {
     this.paused = false;
     this.queuedEntries = [];
@@ -67,13 +76,17 @@ export class SpanielObserver implements SpanielObserverInterface {
 
     this.observer = new IntersectionObserver((records: IntersectionObserverEntry[]) => this.internalCallback(records), o);
 
+    this.onTabHidden = this._onTabHidden.bind(this);
+    this.onWindowClosed = this._onWindowClosed.bind(this);
+    this.onTabShown = this._onTabShown.bind(this);
+
     if (w.hasDOM) {
-      on('unload', this.onWindowClosed.bind(this));
-      on('hide', this.onTabHidden.bind(this));
-      on('show', this.onTabShown.bind(this));
+      on('unload', this.onWindowClosed);
+      on('hide', this.onTabHidden);
+      on('show', this.onTabShown);
     }
   }
-  private onWindowClosed() {
+  private _onWindowClosed() {
     this.onTabHidden();
   }
   private setAllHidden() {
@@ -84,11 +97,11 @@ export class SpanielObserver implements SpanielObserverInterface {
     }
     this.flushQueuedEntries();
   }
-  private onTabHidden() {
+  private _onTabHidden() {
     this.paused = true;
     this.setAllHidden();
   }
-  private onTabShown() {
+  private _onTabShown() {
     this.paused = false;
 
     let ids = Object.keys(this.recordStore);
@@ -223,6 +236,19 @@ export class SpanielObserver implements SpanielObserverInterface {
     this.observer.disconnect();
     this.recordStore = {};
   }
+
+  /*
+   * Must be called when the SpanielObserver is done being used.
+   * This will prevent memory leaks.
+   */
+  destroy() {
+    this.disconnect();
+    if (w.hasDOM) {
+      off('unload', this.onWindowClosed);
+      off('hide', this.onTabHidden);
+      off('show', this.onTabShown);
+    }
+  }
   unobserve(element: SpanielTrackedElement) {
     let record = this.recordStore[element.__spanielId];
     if (record) {
@@ -231,7 +257,7 @@ export class SpanielObserver implements SpanielObserverInterface {
       scheduleWork(() => {
         this.handleRecordExiting(record);
         this.flushQueuedEntries();
-      })
+      });
     }
   }
   observe(target: Element, payload: any = null) {

--- a/test/setup/environment.js
+++ b/test/setup/environment.js
@@ -36,7 +36,7 @@ var runTest = function(threshold, options) {
 }
 
 function cleanUp(value) {
-  value.observer.disconnect();
+  value.observer.destroy();
 }
 
 function wait100ms(result) {


### PR DESCRIPTION
Add proper cleanup method as you are allowed to re-observe after calling `disconnect()`.