### PR TITLE
Attempt to address flaky test

### DIFF
--- a/test/constants.js
+++ b/test/constants.js
@@ -1,7 +1,7 @@
 const constants = {
 	time: {
 		IMPRESSION_THRESHOLD : 100,
-		RAF_THRESHOLD : 16,
+		RAF_THRESHOLD : 32,
 		SMALL: 5
 	},
 	ITEM_TO_OBSERVE: 5,

--- a/test/headless/spaniel-context.js
+++ b/test/headless/spaniel-context.js
@@ -160,6 +160,7 @@ export default class SpanielContext {
   }
 
   waitForExposed(identifierNum) {
+    console.log('Waiting for exposed' + identifierNum);
     if (identifierNum) {
       this.wait(`#exposed-div-${identifierNum}`, 200);
     } else {
@@ -169,6 +170,7 @@ export default class SpanielContext {
   }
 
   waitForNthElemEvent(elementNum, event, identifierNum) {
+    console.log('Waiting for ' + elementNum + ' - ' + event + ' : ' + identifierNum);
     if (identifierNum) {
       this.wait(`#${elementNum}-element-${event}-div-${identifierNum}`, 200);
     } else {

--- a/test/headless/specs/watcher/impression-event.spec.js
+++ b/test/headless/specs/watcher/impression-event.spec.js
@@ -105,7 +105,7 @@ testModule('Impression event', class extends ImpressionEventTestClass {
     return this.setupTest()
       .onDOMReady()
       .scrollTo(200)
-      .wait(RAF_THRESHOLD * 3)
+      .wait(RAF_THRESHOLD)
       .scrollTo(0)
       .assertNever(ITEM_TO_OBSERVE, 'impressed')
       .scrollTo(200)


### PR DESCRIPTION
Wait for `32` ms for anything requiring a `requestAnimationFrame` loop