### PR TITLE
Add boundingClientRect to watcher callback args

### DIFF
--- a/src/native-watcher.ts
+++ b/src/native-watcher.ts
@@ -41,13 +41,15 @@ export interface Threshold {
 export interface WatcherCallbackOptions {
   duration: number;
   visibleTime?: number;
+  boundingClientRect: DOMRectInit;
 }
 
 function onEntry(entries: SpanielObserverEntry[]) {
   entries.forEach((entry: SpanielObserverEntry) => {
-    const { label, duration } = entry;
+    const { label, duration, boundingClientRect } = entry;
     const opts: WatcherCallbackOptions = {
-      duration
+      duration,
+      boundingClientRect
     };
     if (entry.entering) {
       entry.payload.callback(label, opts);

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -40,13 +40,15 @@ export interface Threshold {
 export interface WatcherCallbackOptions {
   duration: number;
   visibleTime?: number;
+  boundingClientRect: DOMRectInit;
 }
 
 function onEntry(entries: SpanielObserverEntry[]) {
   entries.forEach((entry: SpanielObserverEntry) => {
-    const { label, duration } = entry;
+    const { label, duration, boundingClientRect } = entry;
     const opts: WatcherCallbackOptions = {
-      duration
+      duration,
+      boundingClientRect
     };
     if (entry.entering) {
       entry.payload.callback(label, opts);
@@ -77,7 +79,7 @@ export class Watcher {
         ratio: ratio || 0
       });
     }
-    
+
     if (ratio) {
       threshold.push({
         label: 'visible',


### PR DESCRIPTION
`boundingClientRect` is useful for many tracking events