### PR TITLE
Fix typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Spaniel provides additional abstractions on top of [IntersectionObserver](https:
 * Provides the future-proofing of a WCIG API, but with an expanded feature-set built upon said API.
 * Tested and iterated upon in production by LinkedIn since late 2014
 * Highly performant, only relies on `requestAnimationFrame`
-* Extensive `requestAnmiationFrame` task/utility API
+* Extensive `requestAnimationFrame` task/utility API
 
 #### How is it tested?
 


### PR DESCRIPTION
Found a typo in 'requestAnimationFrame'