### PR TITLE
backporting the root implementation with memoize feature

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -111,7 +111,8 @@ The `Watcher` constructor can be passed 3 different options:
 
 * `time` - The time threshold
 * `ratio` - The ratio threshold
-* `rootMargin` - The [rootMargin](https://wicg.github.io/IntersectionObserver/#dom-intersectionobserverinit-rootmargin) in object form.
+* `rootMargin` - The [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#Intersection_observer_options) in object form.
+* `root` - The [root](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#Intersection_observer_options) element with respect to which we want to watch the target. By default it is window.
 
 ## Utility API
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,10 @@ import {
   Frame
 } from './metal/index';
 
+
 import w from './metal/window-proxy';
+
+import { invalidate } from './metal/window-proxy';
 
 export {
   on,
@@ -58,7 +61,8 @@ export {
   SpanielTrackedElement,
   setGlobalEngine,
   getGlobalEngine,
-  w as __w__
+  w as __w__,
+  invalidate
 };
 
 export function queryElement(el: Element, callback: (clientRect: ClientRect, frame: Frame) => void) {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -23,6 +23,7 @@ export interface SpanielObserverInit {
   root?: SpanielTrackedElement;
   rootMargin?: DOMString | DOMMargin; // default: 0px
   threshold?: SpanielThreshold[]; // default: 0
+  ALLOW_CACHED_SCHEDULER?: boolean;
 }
 
 export interface SpanielRecord {
@@ -83,4 +84,5 @@ export interface IntersectionObserverInit {
   root?: SpanielTrackedElement;
   rootMargin?: DOMString; // default: 0px
   threshold?: number | number[]; // default: 0
+  ALLOW_CACHED_SCHEDULER?: boolean;
 }

--- a/src/intersection-observer.ts
+++ b/src/intersection-observer.ts
@@ -132,14 +132,14 @@ export class SpanielIntersectionObserver implements IntersectionObserver {
     this.id = generateToken();
     options.threshold = options.threshold || 0;
     this.rootMarginObj = rootMarginToDOMMargin(options.rootMargin || '0px');
-
+    this.root = options.root;
     if (Array.isArray(options.threshold)) {
       this.thresholds = <Array<number>>options.threshold;
     } else {
       this.thresholds = [<number>options.threshold];
     }
 
-    this.scheduler = new ElementScheduler();
+    this.scheduler = new ElementScheduler(null, this.root, options.ALLOW_CACHED_SCHEDULER);
   }
 };
 
@@ -182,8 +182,8 @@ export class IntersectionObserverEntry implements IntersectionObserverEntryInit 
 export function generateEntry(frame: Frame, clientRect: DOMRectReadOnly, el: Element, rootMargin: DOMMargin): IntersectionObserverEntry {
   let { top, bottom, left, right } = clientRect;
   let rootBounds: ClientRect = {
-    left: rootMargin.left,
-    top: rootMargin.top,
+    left: frame.left + rootMargin.left,
+    top: frame.top + rootMargin.top,
     bottom: rootMargin.bottom,
     right: rootMargin.right,
     width: frame.width - (rootMargin.right + rootMargin.left),

--- a/src/metal/interfaces.ts
+++ b/src/metal/interfaces.ts
@@ -52,17 +52,30 @@ export interface FrameInterface {
   scrollLeft: number;
   width: number;
   height: number;
+  x: number;
+  y: number;
+  top: number;
+  left: number;
 }
 
 export interface MetaInterface {
+  scrollTop: number;
+  scrollLeft: number;
   width: number;
   height: number;
-  scrollLeft: number;
-  scrollTop: number;
+  x: number;
+  y: number;
+  top: number;
+  left: number;
 }
 
-export interface OnWindowIsDirtyInterface {
-  fn: any;
-  scope: any;
-  id: string;
+export interface SpanielClientRectInterface {
+  width: number;
+  height: number;
+  x: number;
+  y: number;
+  bottom: number;
+  top: number;
+  left: number;
+  right: number;
 }

--- a/src/native-watcher.ts
+++ b/src/native-watcher.ts
@@ -21,10 +21,13 @@ import {
   IntersectionObserverClass
 } from './interfaces';
 
+import W from './metal/window-proxy';
+
 export interface WatcherConfig {
   ratio?: number;
   time?: number;
   rootMargin?: DOMString | DOMMargin;
+  root?: SpanielTrackedElement;
 }
 
 export type EventName = 'impressed' | 'exposed' | 'visible' | 'impression-complete';
@@ -62,7 +65,7 @@ function onEntry(entries: SpanielObserverEntry[]) {
 export class Watcher {
   observer: SpanielObserver;
   constructor(ObserverClass: IntersectionObserverClass, config: WatcherConfig = {}) {
-    let { time, ratio, rootMargin } = config;
+    let { time, ratio, rootMargin, root } = config;
 
     let threshold: Threshold[] = [
       {
@@ -79,7 +82,7 @@ export class Watcher {
         ratio: ratio || 0
       });
     }
-    
+
     if (ratio) {
       threshold.push({
         label: 'visible',
@@ -90,7 +93,8 @@ export class Watcher {
 
     this.observer = new SpanielObserver(ObserverClass, onEntry, {
       rootMargin,
-      threshold
+      threshold,
+      root
    });
   }
   watch(el: Element, callback: WatcherCallback) {

--- a/src/spaniel-observer.ts
+++ b/src/spaniel-observer.ts
@@ -33,7 +33,6 @@ import {
 import w from './metal/window-proxy';
 
 import {
-  FrameInterface,
   generateToken,
   on,
   off,
@@ -48,7 +47,7 @@ export function DOMMarginToRootMargin(d: DOMMargin): DOMString {
 
 export class SpanielObserver implements SpanielObserverInterface {
   callback: (entries: SpanielObserverEntry[]) => void;
-  observer: IntersectionObserver;
+  observer: SpanielIntersectionObserver;
   thresholds: SpanielThreshold[];
   recordStore: { [key: string]: SpanielRecord; };
   queuedEntries: SpanielObserverEntry[];
@@ -61,7 +60,7 @@ export class SpanielObserver implements SpanielObserverInterface {
     this.queuedEntries = [];
     this.recordStore = {};
     this.callback = callback;
-    let { root, rootMargin, threshold } = options;
+    let { root, rootMargin, threshold, ALLOW_CACHED_SCHEDULER } = options;
     rootMargin = rootMargin || '0px';
     let convertedRootMargin: DOMString = typeof rootMargin !== 'string' ? DOMMarginToRootMargin(rootMargin) : rootMargin;
     this.thresholds = threshold.sort((t: SpanielThreshold) => t.ratio );
@@ -69,7 +68,8 @@ export class SpanielObserver implements SpanielObserverInterface {
     let o: IntersectionObserverInit = {
       root,
       rootMargin: convertedRootMargin,
-      threshold: this.thresholds.map((t: SpanielThreshold) => t.ratio)
+      threshold: this.thresholds.map((t: SpanielThreshold) => t.ratio),
+      ALLOW_CACHED_SCHEDULER
     };
     this.observer = new SpanielIntersectionObserver((records: IntersectionObserverEntry[]) => this.internalCallback(records), o);
 
@@ -244,8 +244,6 @@ export class SpanielObserver implements SpanielObserverInterface {
       off('unload', this.onWindowClosed);
       off('hide', this.onTabHidden);
       off('show', this.onTabShown);
-
-      w.__destroy__();
     }
   }
   unobserve(element: SpanielTrackedElement) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { SpanielClientRectInterface } from './metal/interfaces';
+
 export function entrySatisfiesRatio(entry: IntersectionObserverEntry, threshold: number) {
   let { boundingClientRect, intersectionRatio } = entry;
 
@@ -13,14 +15,22 @@ export function entrySatisfiesRatio(entry: IntersectionObserverEntry, threshold:
   }
 }
 
-export function getBoundingClientRect(element: Element) {
+export function getBoundingClientRect(element: Element): SpanielClientRectInterface  {
   try {
-    return element.getBoundingClientRect();
+    return element.getBoundingClientRect() as SpanielClientRectInterface;
   } catch (e) {
-    if (typeof e === 'object' && e !== null && e.description.split(' ')[0] === 'Unspecified' && (e.number & 0xFFFF) === 16389) {
-      return { top: 0, bottom: 0, left: 0, width: 0, height: 0, right: 0 };
+    if (typeof e === 'object' && e !== null && (e.number & 0xFFFF) === 16389) {
+      return { top: 0, bottom: 0, left: 0, width: 0, height: 0, right: 0, x: 0, y: 0 };
     } else {
       throw e;
     }
   }
+}
+
+export function throttle(cb: Function, thottleDelay: number = 5, scope = window) {
+  let cookie: any;
+  return () => {
+    scope.clearTimeout(cookie);
+    cookie = scope.setTimeout(cb, thottleDelay);
+  };
 }

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -20,10 +20,14 @@ import {
   SpanielTrackedElement
 } from './interfaces';
 
+import W from './metal/window-proxy';
+
 export interface WatcherConfig {
   ratio?: number;
   time?: number;
   rootMargin?: DOMString | DOMMargin;
+  root?: SpanielTrackedElement;
+  ALLOW_CACHED_SCHEDULER?: boolean;
 }
 
 export type EventName = 'impressed' | 'exposed' | 'visible' | 'impression-complete';
@@ -61,7 +65,7 @@ function onEntry(entries: SpanielObserverEntry[]) {
 export class Watcher {
   observer: SpanielObserver;
   constructor(config: WatcherConfig = {}) {
-    let { time, ratio, rootMargin } = config;
+    let { time, ratio, rootMargin, root, ALLOW_CACHED_SCHEDULER } = config;
 
     let threshold: Threshold[] = [
       {
@@ -89,8 +93,10 @@ export class Watcher {
 
     this.observer = new SpanielObserver(onEntry, {
       rootMargin,
-      threshold
-   });
+      threshold,
+      root,
+      ALLOW_CACHED_SCHEDULER
+    });
   }
   watch(el: Element, callback: WatcherCallback) {
     this.observer.observe(el, {

--- a/test/app/index.html
+++ b/test/app/index.html
@@ -4,9 +4,8 @@
     <link rel="stylesheet" type="text/css" href="style.css" />
   </head>
   <body>
-    <div id="app">
-      
-    </div>
+    <div id="app"></div>
+    <div id="root"></div>
 
     <script type="text/javascript" src="../../exports/spaniel.js"></script>
     <script type="text/javascript" src="setup.js"></script>

--- a/test/app/setup.js
+++ b/test/app/setup.js
@@ -15,3 +15,14 @@ for (var i = 0;  i < 100; i++) {
   app.appendChild(el);
 }
 
+/* Root feature test div */
+var root = document.getElementById('root');
+for (var i = 0;  i < 30; i++) {
+   var id = i + 1;
+   var content = Math.random(0, 100);
+   var el = document.createElement('div');
+   el.setAttribute('class', 'tracked-item-root');
+   el.setAttribute('data-root-target-id', id);
+   el.innerHTML = 'ID: ' + id + ' = ' + content;
+   root.appendChild(el);
+}

--- a/test/app/style.css
+++ b/test/app/style.css
@@ -3,14 +3,15 @@ html, body {
   padding: 0px;
 }
 
-.tracked-item {
+.tracked-item, .tracked-item-root {
   height: 100px;
   background-color: #EEE;
   margin: 0;
   padding: 0;
+  width: 150px;
 }
 
-.tracked-item:nth-child(even) {
+.tracked-item:nth-child(even), .tracked-item-root:nth-child(even) {
   background-color: #DDD;
 }
 
@@ -38,4 +39,14 @@ nav {
 .compose textarea {
   width: 100%;
   height: 100px;
+}
+#app {
+  float: left;
+}
+#root {
+  height: 250px;
+  width: 165px;
+  overflow-y: scroll;
+  float: left;
+  margin-left: 15px;
 }

--- a/test/constants.js
+++ b/test/constants.js
@@ -13,9 +13,12 @@ const constants = {
 	NIGHTMARE: {
 		TIMEOUT: 10,
 		OPTIONS: {
-			show: false,
-			openDevTools: false,
-			waitTimeout: 0
+			// show: true,
+			// openDevTools: {
+			// 	mode: 'detach'
+			// },
+			// dock: true,
+			// closable: true
 		}
 	}
 };

--- a/test/headless/specs/intersection-observer.js
+++ b/test/headless/specs/intersection-observer.js
@@ -230,4 +230,35 @@ testModule('IntersectionObserver', class extends TestClass {
       assert.equal(result, 6, 'Callback fired 6 times');
     });
   }
+
+  ['@test observing an occluded element within a root and scrolling it into view should fire callbacks']() {
+    return this.context.evaluate(function() {
+      window.STATE.impressions = 0;
+      let root = document.getElementById('root');
+      let rootTarget = document.querySelector('.tracked-item-root[data-root-target-id="5"]');
+      let observer = new spaniel.IntersectionObserver(function() {
+        window.STATE.impressions++;
+      }, {
+        root: root,
+        threshold: 0.5
+      });
+      observer.observe(rootTarget);
+      root.addEventListener('scroll', () => spaniel.invalidate(), false);
+    })
+    .wait(100)
+    .evaluate(function() {
+      root.scrollTop = 350;
+    })
+    .wait(100)
+    .evaluate(function() {
+      root.scrollTop = 0;
+    })
+    .wait(100)
+    .getExecution()
+    .evaluate(function() {
+      return window.STATE.impressions;
+    }).then(function(result) {
+      assert.equal(result, 2, 'Callback fired twice');
+    });
+  }
 });

--- a/test/headless/specs/utilities.js
+++ b/test/headless/specs/utilities.js
@@ -21,56 +21,22 @@ const {
 } = constants;
 
 testModule('Window Proxy', class extends TestClass {
-  ['@test destroy works']() {
-    return this.context.evaluate(() => {
-      window.watcher = new spaniel.Watcher();
-      window.target = document.querySelector('.tracked-item[data-id="6"]');
-      window.watcher.watch(window.target, () => {});
-    })
-    .wait(RAF_THRESHOLD * 5)
-    .evaluate(() => {
-      window.watcher.destroy();
-    })
-    .getExecution()
-    .evaluate(function() {
-      return spaniel.__w__.onWindowIsDirtyListeners.length;
-    }).then(function(result) {
-      assert.equal(result, 0, 'All window isDirty listeners have been removed');
-    });
-  }
-  ['@test can listen to window isDirty']() {
-    return this.context.evaluate(() => {
-      window.watcher = new spaniel.Watcher();
-      window.target = document.querySelector('.tracked-item[data-id="6"]');
-      window.watcher.watch(window.target, () => {});
-    })
-    .wait(RAF_THRESHOLD * 5)
-    .getExecution()
-    .evaluate(function() {
-      let id = window.watcher.observer.observer.scheduler.id;
-      return spaniel.__w__.onWindowIsDirtyListeners.filter(listener => listener.id === id);
-    }).then(function(result) {
-      assert.lengthOf(result, 1, 'This watcher is listening on window isDirty');
-    });
-  }
   ['@test window isDirty validation on scroll']() {
     return this.context.evaluate(() => {
-      window.testIsDirty = false;
-      spaniel.__w__.onWindowIsDirtyListeners.push({fn: () => { window.testIsDirty = true }, scope: window, id: 'foo1' });
+      window.lastVersion = spaniel.__w__.version;
     })
     .wait(RAF_THRESHOLD * 5)
-    .scrollTo(10)
+    .scrollTo(100)
     .getExecution()
     .evaluate(function() {
-      return window.testIsDirty;
+      return window.lastVersion !== spaniel.__w__.version;
     }).then(function(result) {
       assert.isTrue(result, 'The window isDirty');
     });
   }
   ['@test window isDirty validation on resize']() {
     return this.context.evaluate(() => {
-      window.testIsDirty = false;
-      spaniel.__w__.onWindowIsDirtyListeners.push({fn: () => { window.testIsDirty = true }, scope: window, id: 'foo2' });
+      window.lastVersion = spaniel.__w__.version;
     })
     .wait(RAF_THRESHOLD * 5)
     .viewport(VIEWPORT.WIDTH + 100, VIEWPORT.HEIGHT + 100)   
@@ -78,7 +44,7 @@ testModule('Window Proxy', class extends TestClass {
     .viewport(VIEWPORT.WIDTH, VIEWPORT.HEIGHT)   
     .getExecution()
     .evaluate(function() {
-      return window.testIsDirty;
+      return window.lastVersion !== spaniel.__w__.version;
     }).then(function(result) {
       assert.isTrue(result, 'The window isDirty');
     });
@@ -168,7 +134,7 @@ testModule('Eventing', class extends TestClass {
       window.STATE.scrollHandler = function() {
         window.STATE.scrollEvents++;
       };
-      spaniel.on('scroll',  window.STATE.scrollHandler);
+      spaniel.on('scroll', window.STATE.scrollHandler);
     })
     .scrollTo(10)
     .wait(RAF_THRESHOLD * 5)

--- a/test/headless/specs/watcher/impression-complete-event.spec.js
+++ b/test/headless/specs/watcher/impression-complete-event.spec.js
@@ -47,6 +47,7 @@ testModule('Impression Complete event', class extends WatcherTestClass {
     return this.context.scrollTo(200)
       .wait(IMPRESSION_THRESHOLD + RAF_THRESHOLD * 4)
       .scrollTo(0)
+      .wait(IMPRESSION_THRESHOLD)
       .assertOnce(ITEM_TO_OBSERVE, 'impression-complete')
       .done();
   }


### PR DESCRIPTION
- Spike for back-porting the v3 `root` implementation within `Intersection-Observer`.
- Handling occluded elements and child scroll containers.