### PR TITLE
Handle zero-area and display: none cases for v2 release branch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ Copyright 2017 LinkedIn Corp. Licensed under the Apache License,
 Version 2.0 (the "License"); you may not use this file except in
 compliance with the License. You may obtain a copy of the License
 at http://www.apache.org/licenses/LICENSE-2.0
- 
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -11,9 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 import { SpanielIntersectionObserver, generateEntry } from './intersection-observer';
 
-import { entrySatisfiesRatio } from './utils';
-
-import { SpanielTrackedElement, SpanielObserverEntry, DOMString, DOMMargin } from './interfaces';
+import { SpanielTrackedElement, DOMMargin } from './interfaces';
 
 export { Watcher, WatcherConfig } from './watcher';
 
@@ -21,7 +19,7 @@ import { SpanielObserver } from './spaniel-observer';
 
 import { setGlobalEngine, getGlobalEngine } from './metal/engine';
 
-import { Scheduler, getGlobalScheduler, on, off, scheduleWork, scheduleRead, Frame } from './metal/index';
+import { getGlobalScheduler, on, off, scheduleWork, scheduleRead, Frame } from './metal/index';
 
 import w from './metal/window-proxy';
 
@@ -46,13 +44,13 @@ export function queryElement(el: Element, callback: (clientRect: ClientRect, fra
 }
 
 export function elementSatisfiesRatio(
-  el: Element,
+  el: HTMLElement,
   ratio: number = 0,
   callback: (result: Boolean) => void,
   rootMargin: DOMMargin = { top: 0, bottom: 0, left: 0, right: 0 }
 ) {
   queryElement(el, (clientRect: ClientRect, frame: Frame) => {
     let entry = generateEntry(frame, clientRect, el, rootMargin);
-    callback(entrySatisfiesRatio(entry, ratio));
+    callback(entry.isIntersecting && entry.intersectionRatio >= ratio);
   });
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -9,7 +9,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 
-export interface SpanielTrackedElement extends Element {
+export interface SpanielTrackedElement extends HTMLElement {
   __spanielId: string;
 }
 

--- a/src/native-spaniel-observer.ts
+++ b/src/native-spaniel-observer.ts
@@ -9,7 +9,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 
-import { entrySatisfiesRatio } from './utils';
+import { calculateIsIntersecting } from './utils';
 
 import {
   IntersectionObserverInit,
@@ -187,9 +187,10 @@ export class SpanielObserver implements SpanielObserverInterface {
         let hasTimeThreshold = !!state.threshold.time;
         let spanielEntry: SpanielObserverEntry = this.generateSpanielEntry(entry, state);
 
-        const ratioSatisfied = entrySatisfiesRatio(entry, state.threshold.ratio);
+        const ratioSatisfied = entry.intersectionRatio >= state.threshold.ratio;
+        const isIntersecting = calculateIsIntersecting(entry);
 
-        if (ratioSatisfied && !state.lastSatisfied) {
+        if (ratioSatisfied && !state.lastSatisfied && isIntersecting) {
           spanielEntry.entering = true;
           if (hasTimeThreshold) {
             state.lastVisible = time;

--- a/src/spaniel-observer.ts
+++ b/src/spaniel-observer.ts
@@ -9,7 +9,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 
-import { entrySatisfiesRatio } from './utils';
+import { calculateIsIntersecting } from './utils';
 
 import { SpanielIntersectionObserver } from './intersection-observer';
 
@@ -191,9 +191,10 @@ export class SpanielObserver implements SpanielObserverInterface {
           let hasTimeThreshold = !!state.threshold.time;
           let spanielEntry: SpanielObserverEntry = this.generateSpanielEntry(entry, state);
 
-          const ratioSatisfied = entrySatisfiesRatio(entry, state.threshold.ratio);
+          const ratioSatisfied = entry.intersectionRatio >= state.threshold.ratio;
+          const isIntersecting = calculateIsIntersecting(entry);
 
-          if (ratioSatisfied && !state.lastSatisfied) {
+          if (ratioSatisfied && !state.lastSatisfied && isIntersecting) {
             spanielEntry.entering = true;
             if (hasTimeThreshold) {
               state.lastVisible = time;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,20 +1,7 @@
 import { SpanielClientRectInterface } from './metal/interfaces';
 
-export function entrySatisfiesRatio(entry: IntersectionObserverEntry, threshold: number) {
-  let { boundingClientRect, intersectionRatio } = entry;
-
-  // Edge case where item has no actual area
-  if (boundingClientRect.width === 0 || boundingClientRect.height === 0) {
-    let { boundingClientRect, intersectionRect } = entry;
-    return (
-      boundingClientRect.left === intersectionRect.left &&
-      boundingClientRect.top === intersectionRect.top &&
-      intersectionRect.width >= 0 &&
-      intersectionRect.height >= 0
-    );
-  } else {
-    return intersectionRatio > threshold || (intersectionRatio === 1 && threshold === 1);
-  }
+export function calculateIsIntersecting({ intersectionRect }: { intersectionRect: ClientRect }) {
+  return intersectionRect.width > 0 || intersectionRect.height > 0;
 }
 
 export function getBoundingClientRect(element: Element): SpanielClientRectInterface {

--- a/test/headless/context.js
+++ b/test/headless/context.js
@@ -1,6 +1,6 @@
 /*
 Copyright 2017 LinkedIn Corp. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- 
+
 Unless required by applicable law or agreed to in writing, software  distributed under the License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 

--- a/test/headless/run.js
+++ b/test/headless/run.js
@@ -16,6 +16,7 @@ server.stdout.on('data', data => {
       '--require',
       '@babel/register',
       'test/headless/specs/**/*.js',
+      'test/headless/specs/*.js',
       '--exit',
       '--timeout',
       '5000'


### PR DESCRIPTION
Attempts to satisfy the spec: https://www.w3.org/TR/intersection-observer/#update-intersection-observations-algo

isIntersecting, non-zero area, and display:nonen are all related, so fixing in one swoop.

Fixes:
#93
#73

Related issues:
w3c/IntersectionObserver#69
w3c/IntersectionObserver#222