### PR TITLE
Fix internal type interface inconsistency with usage

### DIFF
--- a/src/metal/interfaces.ts
+++ b/src/metal/interfaces.ts
@@ -45,7 +45,7 @@ export interface SchedulerInterface extends BaseSchedulerInterface {
 export interface ElementSchedulerInterface extends BaseSchedulerInterface {
   watch: (
     el: Element,
-    callback: (frame: FrameInterface, id: string, clientRect: ClientRect) => void,
+    callback: (frame: FrameInterface, id: string, clientRect?: ClientRect) => void,
     id?: string
   ) => string;
 }

--- a/src/metal/scheduler.ts
+++ b/src/metal/scheduler.ts
@@ -233,7 +233,7 @@ export class ElementScheduler extends BaseScheduler implements ElementSchedulerI
 
   watch(
     el: Element,
-    callback: (frame: FrameInterface, id: string, clientRect?: ClientRect | null) => void,
+    callback: (frame: FrameInterface, id: string, clientRect?: ClientRect) => void,
     id?: string
   ): string {
     this.startTicking();


### PR DESCRIPTION
The `ElementScheduler` implementation does not require `clientRect`. Need to dig into why the complier allows this. Other builds are failing against this issue.