### PR TITLE
Use the original boundingClientRect on exiting viewport

### DIFF
--- a/src/native-spaniel-observer.ts
+++ b/src/native-spaniel-observer.ts
@@ -135,6 +135,7 @@ export class SpanielObserver implements SpanielObserverInterface {
   }
   private handleRecordExiting(record: SpanielRecord, time: number = Date.now()) {
     record.thresholdStates.forEach((state: SpanielThresholdState) => {
+      const boundingClientRect = record.lastSeenEntry && record.lastSeenEntry.boundingClientRect;
       this.handleThresholdExiting(
         {
           intersectionRatio: -1,
@@ -143,7 +144,7 @@ export class SpanielObserver implements SpanielObserverInterface {
           label: state.threshold.label,
           entering: false,
           rootBounds: emptyRect,
-          boundingClientRect: emptyRect,
+          boundingClientRect: boundingClientRect || emptyRect,
           intersectionRect: emptyRect,
           duration: time - state.lastVisible,
           target: record.target,

--- a/src/spaniel-observer.ts
+++ b/src/spaniel-observer.ts
@@ -145,6 +145,7 @@ export class SpanielObserver implements SpanielObserverInterface {
   }
   private handleRecordExiting(record: SpanielRecord, time: number = Date.now()) {
     record.thresholdStates.forEach((state: SpanielThresholdState) => {
+      const boundingClientRect = record.lastSeenEntry && record.lastSeenEntry.boundingClientRect;
       this.handleThresholdExiting(
         {
           intersectionRatio: -1,
@@ -153,7 +154,7 @@ export class SpanielObserver implements SpanielObserverInterface {
           label: state.threshold.label,
           entering: false,
           rootBounds: emptyRect,
-          boundingClientRect: emptyRect,
+          boundingClientRect: boundingClientRect || emptyRect,
           intersectionRect: emptyRect,
           duration: time - state.lastVisible,
           target: record.target,


### PR DESCRIPTION
When an element is exiting the viewport, we want to know the boundingClientRect of the element the instant before it left the viewport. An empty rect doesn't provide relevant information and will always be the effective measurement of the element after leaving the viewport.