### PR TITLE
Use the original boundingClientRect on exiting viewport

### DIFF
--- a/src/native-spaniel-observer.ts
+++ b/src/native-spaniel-observer.ts
@@ -136,6 +136,7 @@ export class SpanielObserver implements SpanielObserverInterface {
   }
   private handleRecordExiting(record: SpanielRecord, time: number = Date.now()) {
     record.thresholdStates.forEach((state: SpanielThresholdState) => {
+      const boundingClientRect = record.lastSeenEntry && record.lastSeenEntry.boundingClientRect;
       this.handleThresholdExiting(
         {
           intersectionRatio: -1,
@@ -145,7 +146,7 @@ export class SpanielObserver implements SpanielObserverInterface {
           label: state.threshold.label,
           entering: false,
           rootBounds: emptyRect,
-          boundingClientRect: emptyRect,
+          boundingClientRect: boundingClientRect || emptyRect,
           intersectionRect: emptyRect,
           duration: time - state.lastVisible,
           target: record.target

--- a/src/spaniel-observer.ts
+++ b/src/spaniel-observer.ts
@@ -143,6 +143,7 @@ export class SpanielObserver implements SpanielObserverInterface {
   }
   private handleRecordExiting(record: SpanielRecord, time: number = Date.now()) {
     record.thresholdStates.forEach((state: SpanielThresholdState) => {
+      const boundingClientRect = record.lastSeenEntry && record.lastSeenEntry.boundingClientRect;
       this.handleThresholdExiting(
         {
           intersectionRatio: -1,
@@ -152,7 +153,7 @@ export class SpanielObserver implements SpanielObserverInterface {
           label: state.threshold.label,
           entering: false,
           rootBounds: emptyRect,
-          boundingClientRect: emptyRect,
+          boundingClientRect: boundingClientRect || emptyRect,
           intersectionRect: emptyRect,
           duration: time - state.lastVisible,
           target: record.target


### PR DESCRIPTION
v2 version of: https://github.com/linkedin/spaniel/pull/122

When an element is exiting the viewport, we want to know the boundingClientRect of the element the instant before it left the viewport. An empty rect doesn't provide helpful information and will always be the effective measurement of the element after leaving the viewport