### PR TITLE
Handle bootup in background tab edge case

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -24,6 +24,7 @@ export interface SpanielObserverInit {
   rootMargin?: DOMString | DOMMargin; // default: 0px
   threshold: SpanielThreshold[]; // default: 0
   ALLOW_CACHED_SCHEDULER?: boolean;
+  BACKGROUND_TAB_FIX?: boolean;
 }
 
 export interface SpanielRecord {

--- a/src/metal/window-proxy.ts
+++ b/src/metal/window-proxy.ts
@@ -26,6 +26,7 @@ interface WindowProxy {
   lastVersion: number;
   updateMeta: Function;
   isDirty: boolean;
+  document: Document;
 }
 
 const hasDOM = !!(typeof window !== 'undefined' && window && typeof document !== 'undefined' && document);
@@ -58,7 +59,8 @@ let W: WindowProxy = {
   updateMeta: nop,
   get isDirty(): boolean {
     return W.version !== W.lastVersion;
-  }
+  },
+  document: window.document
 };
 
 export function invalidate() {

--- a/src/spaniel-observer.ts
+++ b/src/spaniel-observer.ts
@@ -47,7 +47,7 @@ export class SpanielObserver implements SpanielObserverInterface {
     this.queuedEntries = [];
     this.recordStore = {};
     this.callback = callback;
-    let { root, rootMargin, threshold, ALLOW_CACHED_SCHEDULER } =
+    let { root, rootMargin, threshold, ALLOW_CACHED_SCHEDULER, BACKGROUND_TAB_FIX } =
       options ||
       ({
         threshold: []
@@ -76,6 +76,9 @@ export class SpanielObserver implements SpanielObserverInterface {
       on('beforeunload', this.onWindowClosed);
       on('hide', this.onTabHidden);
       on('show', this.onTabShown);
+      if (BACKGROUND_TAB_FIX) {
+        this.paused = w.document.visibilityState !== 'visible';
+      }
     }
   }
   private _onWindowClosed() {

--- a/test/app/setup.js
+++ b/test/app/setup.js
@@ -1,7 +1,7 @@
 /*
-Copyright 2017 LinkedIn Corp. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Copyright 2017 LinkedIn Corp. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  
-Unless required by applicable law or agreed to in writing, software  distributed under the License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 
 var app = document.getElementById('app');

--- a/test/specs/spaniel-observer.spec.js
+++ b/test/specs/spaniel-observer.spec.js
@@ -1,7 +1,7 @@
 /*
-Copyright 2017 LinkedIn Corp. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Copyright 2017 LinkedIn Corp. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+Unless required by applicable law or agreed to in writing, softwaredistributed under the License is distributed on an "AS IS" BASIS,WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 
 var expect = chai.expect;
@@ -28,7 +28,8 @@ function runTest(threshold, options) {
     },
     {
       rootMargin: '0px 0px',
-      threshold: thresholds
+      threshold: thresholds,
+      BACKGROUND_TAB_FIX: options.BACKGROUND_TAB_FIX
     }
   );
   observer.observe(target);
@@ -199,6 +200,34 @@ describe('SpanielObserver', function() {
       .then(function(result) {
         var entries = result.entries;
         expect(entries.length).to.equal(0);
+        return result;
+      })
+      .then(cleanUp);
+  });
+
+  it('should start paused if in a background tab', function() {
+    var target = document.createElement('div');
+    spaniel.__w__.document = { visibilityState: 'hidden' };
+
+    return runTest(
+      {
+        label: 'impression',
+        ratio: 0.5
+      },
+      {
+        target: target,
+        document: { visibilityState: 'hidden' },
+        BACKGROUND_TAB_FIX: true
+      }
+    )
+      .then(function(result) {
+        // Observer should be paused right out of the gate
+        expect(result.observer.paused).to.equal(true);
+
+        // Closing the tab when it never entered the foreground should not trigger any impression events
+        result.observer.onWindowClosed();
+        expect(result.observer.paused).to.equal(true);
+        expect(result.entries.length).to.equal(0);
         return result;
       })
       .then(cleanUp);


### PR DESCRIPTION
@xg-wang recently discovered an edge case where by:

- opening an app in a backgrounded tab
- closing that tab

Spaniel will fire Impression events in both Safari and Firefox. It is currently unknown why this doesn't happen in Chrome.

Previously, Spaniel assumes that the app is visible (and changes this state in response to the browsers visibilitychange event).
This PR ensures that Spaniel does not assume the app is visible.