### PR TITLE
Use the intersection observers given timestamp

### DIFF
--- a/src/metal/window-proxy.ts
+++ b/src/metal/window-proxy.ts
@@ -30,6 +30,7 @@ interface WindowProxy {
   isDirty: boolean;
   document: Document;
   IntersectionObserver: IntersectionObserverClass;
+  performance: Performance;
 }
 
 const hasDOM = !!(typeof window !== 'undefined' && window && typeof document !== 'undefined' && document);
@@ -64,7 +65,8 @@ let W: WindowProxy = {
     return W.version !== W.lastVersion;
   },
   document: window.document,
-  IntersectionObserver: hasDOM && (window as any).IntersectionObserver
+  IntersectionObserver: hasDOM && (window as any).IntersectionObserver,
+  performance: hasDOM && (window as any).performance
 };
 
 export function invalidate() {


### PR DESCRIPTION
We want to use the intersection observers timestamp, intstead of re-calculating a timestamp in a callback which doesn't happen exactly when intersection. happens. Native intersection observer and polyfill use different typestamps unforunately, so we need to do some massaging.