### PR TITLE
Use document as default root

### DIFF
--- a/src/metal/scheduler.ts
+++ b/src/metal/scheduler.ts
@@ -57,7 +57,7 @@ export class Frame implements FrameInterface {
       rootMeta.left
     );
   }
-  static revalidateRootMeta(root: any = window): MetaInterface {
+  static revalidateRootMeta(root: any = document): MetaInterface {
     let _clientRect = null;
     let _rootMeta: MetaInterface = {
       width: 0,
@@ -75,7 +75,7 @@ export class Frame implements FrameInterface {
       W.updateMeta();
     }
 
-    if (root === window) {
+    if (root === window || root === document) {
       _rootMeta.height = W.meta.height;
       _rootMeta.width = W.meta.width;
       _rootMeta.scrollLeft = W.meta.scrollLeft;


### PR DESCRIPTION
`document`, not `window` should be the default root
https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/root