### PR TITLE
Expose visibleTime and intersectionRect for all watcher events

### DIFF
--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -36,14 +36,17 @@ export interface WatcherCallbackOptions {
   duration: number;
   visibleTime?: number;
   boundingClientRect: DOMRectInit;
+  intersectionRect: DOMRectInit;
 }
 
 function onEntry(entries: SpanielObserverEntry[]) {
   entries.forEach((entry: SpanielObserverEntry) => {
-    const { label, duration, boundingClientRect } = entry;
+    const { label, duration, boundingClientRect, intersectionRect } = entry;
     const opts: WatcherCallbackOptions = {
       duration,
-      boundingClientRect
+      boundingClientRect,
+      visibleTime: entry.time,
+      intersectionRect
     };
     if (entry.entering) {
       entry.payload.callback(label, opts);

--- a/test/headless/specs/watcher/exposed-event.spec.js
+++ b/test/headless/specs/watcher/exposed-event.spec.js
@@ -1,7 +1,7 @@
 /*
-Copyright 2017 LinkedIn Corp. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Copyright 2017 LinkedIn Corp. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  
-Unless required by applicable law or agreed to in writing, software  distributed under the License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 
 import { assert } from 'chai';


### PR DESCRIPTION
* `visibleTime` is relevant for all event types, but we were only exposing the parameter for `impression-complete` meta.
* Expose `interesectionRect` in the event metadata
* Add tests for metadata