### PR TITLE
Fix test issue with collecting initial page load events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 dist: trusty
 node_js:
-  - "12.13.1"
+  - "16.6.2"
 sudo: false
 branches:
   only:

--- a/test/playwright/modules/visible-time.ts
+++ b/test/playwright/modules/visible-time.ts
@@ -1,9 +1,9 @@
 import { test, expect } from '@playwright/test';
-import { getPageAssertions, getPageState, pageScroll, timestampsAreClose } from '../utils';
+import { getInitialPageState, getPageAssertions, pageScroll, timestampsAreClose } from '../utils';
 
 export function visibleTimeModule() {
   test('visibleTime for initial events are close to page load time', async ({ page }) => {
-    const { time, assertions } = await getPageState(page);
+    const { time, assertions } = await getInitialPageState(page, 25);
     expect(assertions.length).toBe(1);
     for (let i = 0; i < assertions[0].length; i++) {
       const a = assertions[0][i];
@@ -12,7 +12,7 @@ export function visibleTimeModule() {
   });
 
   test('visibleTime for events after scrolling is still from initial load', async ({ page }) => {
-    const initialState = await getPageState(page);
+    const initialState = await getInitialPageState(page, 25);
     expect(initialState.assertions.length).toBe(1);
     const initialAssertionIndex = initialState.assertions[0].length;
     await page.waitForTimeout(500);
@@ -25,10 +25,8 @@ export function visibleTimeModule() {
   });
 
   test('duration impression-complete is the time items were in viewport', async ({ page }) => {
-    const initialState = await getPageState(page);
     const timeInViewport = 500;
     await page.waitForTimeout(timeInViewport);
-    expect(initialState.assertions.length).toBe(1);
     await pageScroll(page, 1000, true);
     const assertions = await getPageAssertions(page);
     const impressionCompleteAssertions = assertions[0].filter(a => a.e === 'impression-complete');

--- a/test/playwright/utils.ts
+++ b/test/playwright/utils.ts
@@ -33,6 +33,30 @@ interface PageState {
   assertions: SpanielAssertion[][];
 }
 
+/*
+ * Helper for grabbing the initial page load time and then assertions from the initial page load
+ */
+export async function getInitialPageState(page: Page, expectedAssertions: number): Promise<PageState> {
+  const INITIAL_EVENT_GRACE_PERIOD = 500;
+
+  const time = await getPageTime(page);
+
+  // Wait for initial impression events to fire
+  await page.waitForTimeout(INITIAL_EVENT_GRACE_PERIOD);
+  const assertions = await getPageAssertions(page);
+  expect(assertions.length).toBe(1);
+
+  // This assertion just makes sure the INITIAL_EVENT_GRACE_PERIOD works
+  // If the following assertion fails, probably means the page is taking longer
+  // Than expected to boot
+  expect(assertions[0].length).toBe(expectedAssertions);
+
+  return {
+    time,
+    assertions
+  };
+}
+
 export async function getPageState(page: Page): Promise<PageState> {
   const [time, assertions] = await Promise.all([getPageTime(page), getPageAssertions(page)]);
   return {


### PR DESCRIPTION
When a webpage boots and elements are instrumented with a watcher, the watcher will fire exposed events during page boot for elements that are above the fold. Firing these exposed events are not instantaneous and our tests were not waiting enough to capture all of them. Adding some grace period to wait until these events are collected.