### PR TITLE
Add test for tab hidden entry properties

### DIFF
--- a/test/playwright/modules/spaniel-observer-tests.ts
+++ b/test/playwright/modules/spaniel-observer-tests.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { SpanielObserverEntry } from '../../../src/interfaces';
-import { getPageAssertions, getPageTime, timestampsAreClose } from '../utils';
+import { getPageAssertions, getPageTime, pageHide, timestampsAreClose } from '../utils';
 
 function runTests() {
   test('time for initial events are close to page load time', async ({ page }) => {
@@ -12,6 +12,24 @@ function runTests() {
     for (let i = 0; i < assertions.length; i++) {
       const a = assertions[i];
       timestampsAreClose(loadTime, a.time);
+    }
+  });
+
+  test('tab hidden entries have correct fields', async ({ page }) => {
+    const loadTime = await getPageTime(page);
+    const delay = 1500;
+    await page.waitForTimeout(delay);
+    await pageHide(page);
+    await page.waitForTimeout(500);
+    const assertions = await getPageAssertions<SpanielObserverEntry>(page);
+    expect(assertions.length).toEqual(4);
+    // Exiting events
+    for (let i = 2; i < assertions.length; i++) {
+      const a = assertions[i];
+      timestampsAreClose(delay, a.duration);
+      expect(a.isIntersecting).toBeFalsy();
+      expect(a.entering).toBeFalsy();
+      timestampsAreClose(loadTime + delay, a.time);
     }
   });
 }

--- a/test/playwright/utils.ts
+++ b/test/playwright/utils.ts
@@ -67,3 +67,29 @@ export async function pageScroll(page: Page, amount: number, waitAfter: boolean 
   }
   await page.waitForTimeout(typeof waitAfter === 'boolean' ? STANDARD_SCROLL_WAIT : waitAfter);
 }
+
+// workaround: https://github.com/microsoft/playwright/issues/2286
+export async function pageHide(page: Page): Promise<void> {
+  // https://github.com/linkedin/spaniel/blob/master/src/metal/events.ts
+  await page.evaluate(`Object.defineProperty(document, 'visibilityState', {
+    value: 'hidden',
+    configurable: true
+  })`);
+  // _visibilityHandler addon/services/tracking.js#747
+  await page.evaluate(`Object.defineProperty(document, 'hidden', {
+    value: true,
+    configurable: true
+  })`);
+  await page.evaluate(`document.dispatchEvent(new Event('visibilitychange'))`);
+}
+export async function pageShow(page: Page): Promise<void> {
+  await page.evaluate(`Object.defineProperty(document, 'visibilityState', {
+    value: 'visible',
+    configurable: true
+  })`);
+  await page.evaluate(`Object.defineProperty(document, 'hidden', {
+    value: false,
+    configurable: true
+  })`);
+  await page.evaluate(`document.dispatchEvent(new Event('visibilitychange'))`);
+}


### PR DESCRIPTION
Test the key entry properties for entries fired when the tab is hidden.