### PR TITLE
Add back WatcherCallbackOptions export

### DIFF
--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -30,6 +30,7 @@ export interface WatcherConfig {
 
 export type EventName = 'impressed' | 'exposed' | 'visible' | 'impression-complete';
 
+export { WatcherCallbackOptions };
 export type WatcherCallback = (eventName: EventName, callback: WatcherCallbackOptions) => void;
 
 export interface Threshold {


### PR DESCRIPTION
This previous change broke type resolution: https://github.com/linkedin/spaniel/pull/150/files#diff-2207093beefcc6234a2205469f9b96ca2549952abdc72fb9390daf9ce4a20855L35

This change fixes the error:
 Module '"../../node_modules/spaniel/exports/watcher"' declares 'WatcherCallbackOptions' locally, but it is not exported.