### PR TITLE
Better typing for spaniel observer payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # spaniel Changelog
 
+### 2.8.0 (November 17, 2021)
+
+* Allow specifying the SpanielObserver payload type via a generic
+* Support specifying a typed metadata field for each watcher threshold
+
 ### 2.7.0 (November 17, 2020)
 
 * Expose `intersectionRect` in watcher callback metadata parameter

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spaniel",
-  "version": "2.7.5",
+  "version": "2.8.0",
   "description": "LinkedIn's viewport tracking library",
   "license": "Apache 2.0",
   "main": "exports/spaniel.js",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -13,16 +13,17 @@ export interface SpanielTrackedElement extends HTMLElement {
   __spanielId: string;
 }
 
-export interface SpanielThreshold {
+export interface SpanielThreshold<Meta = undefined> {
   label: string;
+  meta: Meta;
   ratio: number;
   time?: number;
 }
 
-export interface SpanielObserverInit {
+export interface SpanielObserverInit<ThresholdMeta = undefined> {
   root?: SpanielTrackedElement;
   rootMargin?: DOMString | DOMMargin; // default: 0px
-  threshold: SpanielThreshold[]; // default: 0
+  threshold: SpanielThreshold<ThresholdMeta>[]; // default: 0
   ALLOW_CACHED_SCHEDULER?: boolean;
   BACKGROUND_TAB_FIX?: boolean;
   USE_NATIVE_IO?: boolean;
@@ -33,17 +34,17 @@ export interface TimeCompat {
   unixTime: number;
 }
 
-export interface SpanielRecord {
+export interface SpanielRecord<ThresholdMeta> {
   target: SpanielTrackedElement;
   payload: any;
-  thresholdStates: SpanielThresholdState[];
+  thresholdStates: SpanielThresholdState<ThresholdMeta>[];
   lastSeenEntry: InternalIntersectionObserverEntry | null;
 }
 
-export interface SpanielThresholdState {
+export interface SpanielThresholdState<ThresholdMeta> {
   lastSatisfied: Boolean;
   lastEntry: InternalIntersectionObserverEntry | null;
-  threshold: SpanielThreshold;
+  threshold: SpanielThreshold<ThresholdMeta>;
   lastVisible: TimeCompat;
   visible: boolean;
   timeoutId?: number;
@@ -65,14 +66,15 @@ export interface SpanielRect extends DOMRectPojo {
   readonly y: number;
 }
 
-export interface SpanielObserverEntry {
+export interface SpanielObserverEntry<ThresholdMeta = undefined, ObservePayload = undefined> {
   isIntersecting: boolean;
   duration: number;
   visibleTime: number;
   intersectionRatio: number;
   entering: boolean;
   label?: string;
-  payload?: any;
+  thresholdMeta: ThresholdMeta;
+  payload: ObservePayload;
   unixTime: number;
   highResTime: number;
   time: number;

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -15,6 +15,7 @@ import {
   DOMString,
   DOMMargin,
   SpanielTrackedElement,
+  SpanielThreshold,
   WatcherCallbackOptions
 } from './interfaces';
 
@@ -39,8 +40,12 @@ export interface Threshold {
   ratio: number;
 }
 
-function onEntry(entries: SpanielObserverEntry[]) {
-  entries.forEach((entry: SpanielObserverEntry) => {
+interface WatcherObservePayload {
+  callback: (label: string | undefined, opts: WatcherCallbackOptions) => void;
+}
+
+function onEntry(entries: SpanielObserverEntry<undefined, WatcherObservePayload>[]) {
+  entries.forEach((entry: SpanielObserverEntry<undefined, WatcherObservePayload>) => {
     const { label, duration, boundingClientRect, intersectionRect } = entry;
     const opts: WatcherCallbackOptions = {
       duration,
@@ -57,13 +62,14 @@ function onEntry(entries: SpanielObserverEntry[]) {
 }
 
 export class Watcher {
-  observer: SpanielObserver;
+  observer: SpanielObserver<undefined, WatcherObservePayload>;
   constructor(config: WatcherConfig = {}) {
     let { time, ratio, rootMargin, root, ALLOW_CACHED_SCHEDULER, BACKGROUND_TAB_FIX, USE_NATIVE_IO } = config;
 
-    let threshold: Threshold[] = [
+    let threshold: SpanielThreshold<undefined>[] = [
       {
         label: 'exposed',
+        meta: undefined,
         time: 0,
         ratio: 0
       }
@@ -72,6 +78,7 @@ export class Watcher {
     if (time != null) {
       threshold.push({
         label: 'impressed',
+        meta: undefined,
         time,
         ratio: ratio || 0
       });
@@ -80,12 +87,13 @@ export class Watcher {
     if (ratio) {
       threshold.push({
         label: 'visible',
+        meta: undefined,
         time: 0,
         ratio
       });
     }
 
-    this.observer = new SpanielObserver(onEntry, {
+    this.observer = new SpanielObserver<undefined, WatcherObservePayload>(onEntry, {
       rootMargin,
       threshold,
       root,

--- a/test/specs/spaniel-observer.spec.js
+++ b/test/specs/spaniel-observer.spec.js
@@ -62,6 +62,9 @@ describe('SpanielObserver', function() {
   it('should fire impression event with correct info', function() {
     return runTest({
       label: 'impression',
+      meta: {
+        foo: 'my-special-meta'
+      },
       ratio: 0.5
     })
       .then(function(result) {
@@ -71,6 +74,7 @@ describe('SpanielObserver', function() {
         expect(entry.entering, true);
         expect(entry.label, 'impression');
         expect(entry.intersectionRatio, 1);
+        expect(entry.thresholdMeta.foo, 'my-special-meta');
         return result;
       })
       .then(cleanUp);


### PR DESCRIPTION
Previously, the spaniel observer entry payload was typed with "any." This is obviously bad, and I've updated the code to use a generic instead, so the payload is typed. I also added a metadata field on thresholds so that the spaniel observer entry can provide more detailed information about the threshold that was crossed, rather than relying on just the label