### PR TITLE
Better typing for spaniel observer payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # spaniel Changelog
 
+### 2.8.0 (November 17, 2021)
+
+* Allow specifying the SpanielObserver payload type via a generic, instead of the `any` type
+
 ### 2.7.0 (November 17, 2020)
 
 * Expose `intersectionRect` in watcher callback metadata parameter

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spaniel",
-  "version": "2.7.5",
+  "version": "2.8.0",
   "description": "LinkedIn's viewport tracking library",
   "license": "Apache 2.0",
   "main": "exports/spaniel.js",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -65,14 +65,14 @@ export interface SpanielRect extends DOMRectPojo {
   readonly y: number;
 }
 
-export interface SpanielObserverEntry {
+export interface SpanielObserverEntry<ObservePayload = undefined> {
   isIntersecting: boolean;
   duration: number;
   visibleTime: number;
   intersectionRatio: number;
   entering: boolean;
-  label?: string;
-  payload?: any;
+  label: string;
+  payload: ObservePayload;
   unixTime: number;
   highResTime: number;
   time: number;

--- a/src/spaniel-observer.ts
+++ b/src/spaniel-observer.ts
@@ -34,18 +34,18 @@ export function DOMMarginToRootMargin(d: DOMMargin): DOMString {
   return `${d.top}px ${d.right}px ${d.bottom}px ${d.left}px`;
 }
 
-export class SpanielObserver implements SpanielObserverInterface {
-  callback: (entries: SpanielObserverEntry[]) => void;
+export class SpanielObserver<ObservePayload = undefined> implements SpanielObserverInterface {
+  callback: (entries: SpanielObserverEntry<ObservePayload>[]) => void;
   observer: SpanielIntersectionObserver | IntersectionObserver;
   thresholds: SpanielThreshold[];
   recordStore: { [key: string]: SpanielRecord };
-  queuedEntries: SpanielObserverEntry[];
+  queuedEntries: SpanielObserverEntry<ObservePayload>[];
   private paused: boolean;
   private usingNativeIo: boolean;
   private onWindowClosed: () => void;
   private onTabHidden: () => void;
   private onTabShown: () => void;
-  constructor(callback: (entries: SpanielObserverEntry[]) => void, options?: SpanielObserverInit) {
+  constructor(callback: (entries: SpanielObserverEntry<ObservePayload>[]) => void, options?: SpanielObserverInit) {
     this.paused = false;
     this.queuedEntries = [];
     this.recordStore = {};
@@ -58,7 +58,7 @@ export class SpanielObserver implements SpanielObserverInterface {
     rootMargin = rootMargin || '0px';
     let convertedRootMargin: DOMString =
       typeof rootMargin !== 'string' ? DOMMarginToRootMargin(rootMargin) : rootMargin;
-    this.thresholds = threshold.sort((t: SpanielThreshold) => t.ratio);
+    this.thresholds = threshold.sort(t => t.ratio);
 
     let o: IntersectionObserverInit = {
       root,
@@ -141,7 +141,7 @@ export class SpanielObserver implements SpanielObserverInterface {
   private generateSpanielEntry(
     entry: InternalIntersectionObserverEntry,
     state: SpanielThresholdState
-  ): SpanielObserverEntry {
+  ): SpanielObserverEntry<ObservePayload> {
     let { intersectionRatio, rootBounds, boundingClientRect, intersectionRect, isIntersecting, time, target } = entry;
     let record = this.recordStore[(<SpanielTrackedElement>target).__spanielId];
     const unixTime = this.usingNativeIo
@@ -198,7 +198,7 @@ export class SpanielObserver implements SpanielObserverInterface {
       state.lastEntry = null;
     });
   }
-  private handleThresholdExiting(spanielEntry: SpanielObserverEntry, state: SpanielThresholdState) {
+  private handleThresholdExiting(spanielEntry: SpanielObserverEntry<ObservePayload>, state: SpanielThresholdState) {
     let { highResTime } = spanielEntry;
     let hasTimeThreshold = !!state.threshold.time;
     if (state.lastSatisfied && (!hasTimeThreshold || (hasTimeThreshold && state.visible))) {
@@ -223,7 +223,7 @@ export class SpanielObserver implements SpanielObserverInterface {
           // Find the thresholds that were crossed. Since you can have multiple thresholds
           // for the same ratio, could be multiple thresholds
           let hasTimeThreshold = !!state.threshold.time;
-          let spanielEntry: SpanielObserverEntry = this.generateSpanielEntry(entry, state);
+          let spanielEntry: SpanielObserverEntry<ObservePayload> = this.generateSpanielEntry(entry, state);
 
           const ratioSatisfied = entry.intersectionRatio >= state.threshold.ratio;
 

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -15,6 +15,7 @@ import {
   DOMString,
   DOMMargin,
   SpanielTrackedElement,
+  SpanielThreshold,
   WatcherCallbackOptions
 } from './interfaces';
 
@@ -39,8 +40,12 @@ export interface Threshold {
   ratio: number;
 }
 
-function onEntry(entries: SpanielObserverEntry[]) {
-  entries.forEach((entry: SpanielObserverEntry) => {
+interface WatcherObservePayload {
+  callback: (label: string, opts: WatcherCallbackOptions) => void;
+}
+
+function onEntry(entries: SpanielObserverEntry<WatcherObservePayload>[]) {
+  entries.forEach((entry: SpanielObserverEntry<WatcherObservePayload>) => {
     const { label, duration, boundingClientRect, intersectionRect } = entry;
     const opts: WatcherCallbackOptions = {
       duration,
@@ -57,11 +62,11 @@ function onEntry(entries: SpanielObserverEntry[]) {
 }
 
 export class Watcher {
-  observer: SpanielObserver;
+  observer: SpanielObserver<WatcherObservePayload>;
   constructor(config: WatcherConfig = {}) {
     let { time, ratio, rootMargin, root, ALLOW_CACHED_SCHEDULER, BACKGROUND_TAB_FIX, USE_NATIVE_IO } = config;
 
-    let threshold: Threshold[] = [
+    let threshold: SpanielThreshold[] = [
       {
         label: 'exposed',
         time: 0,
@@ -85,7 +90,7 @@ export class Watcher {
       });
     }
 
-    this.observer = new SpanielObserver(onEntry, {
+    this.observer = new SpanielObserver<WatcherObservePayload>(onEntry, {
       rootMargin,
       threshold,
       root,


### PR DESCRIPTION
Previously, the spaniel observer entry payload was typed with "any." This is obviously bad, and I've updated the code to use a generic instead, so the payload is typed. Also, we were defining label as optional in the spaniel observer entry, when it is guaranteed to exist since we have always required the label in the threshold that users provide.