### PR TITLE
Add threshold property to SpanielObserverEntry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # spaniel Changelog
 
-### 2.8.0 (November 17, 2021)
+### 2.8.0 (August 18, 2021)
 
 * Allow specifying the SpanielObserver payload type via a generic, instead of the `any` type
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # spaniel Changelog
 
+### 2.9.0 (August 19, 2021)
+
+* Add the `threshold` field to `SpanielObserverEntry` so that entries denote parameters of the threshold that was crossed
+
 ### 2.8.0 (August 18, 2021)
 
 * Allow specifying the SpanielObserver payload type via a generic, instead of the `any` type

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spaniel",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "LinkedIn's viewport tracking library",
   "license": "Apache 2.0",
   "main": "exports/spaniel.js",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -73,6 +73,7 @@ export interface SpanielObserverEntry<ObservePayload = undefined> {
   entering: boolean;
   label: string;
   payload: ObservePayload;
+  threshold: SpanielThreshold;
   unixTime: number;
   highResTime: number;
   time: number;

--- a/src/spaniel-observer.ts
+++ b/src/spaniel-observer.ts
@@ -165,7 +165,8 @@ export class SpanielObserver<ObservePayload = undefined> implements SpanielObser
       visibleTime: isIntersecting ? unixTime : -1,
       entering: false,
       payload: record.payload,
-      label: state.threshold.label
+      label: state.threshold.label,
+      threshold: state.threshold
     };
   }
   private handleRecordExiting(record: SpanielRecord) {
@@ -182,6 +183,7 @@ export class SpanielObserver<ObservePayload = undefined> implements SpanielObser
           highResTime: perfTime,
           payload: record.payload,
           label: state.threshold.label,
+          threshold: state.threshold,
           entering: false,
           rootBounds: emptyRect,
           boundingClientRect: boundingClientRect || emptyRect,

--- a/test/playwright/modules/spaniel-observer-tests.ts
+++ b/test/playwright/modules/spaniel-observer-tests.ts
@@ -3,7 +3,7 @@ import { SpanielObserverEntry } from '../../../src/interfaces';
 import { getPageAssertions, getPageTime, pageHide, pageScroll, pageShow, timestampsAreClose } from '../utils';
 
 function runTests() {
-  test('time for initial events are close to page load time', async ({ page }) => {
+  test('basic fields for initial events are close to page load time', async ({ page }) => {
     const loadTime = await getPageTime(page);
     const delay = 1500;
     await page.waitForTimeout(delay);
@@ -12,7 +12,12 @@ function runTests() {
     for (let i = 0; i < assertions.length; i++) {
       const a = assertions[i];
       timestampsAreClose(loadTime, a.time);
+      expect(a.entering).toBeTruthy();
+      expect(a.isIntersecting).toBeTruthy();
     }
+    expect(assertions[0].threshold.ratio).toEqual(0);
+    expect(assertions[1].threshold.ratio).toEqual(0.5);
+    expect(assertions[1].threshold.time).toEqual(1000);
   });
 
   test('time for shown events after being hidden a long time by scrolling are correct', async ({ page }) => {
@@ -27,6 +32,8 @@ function runTests() {
     for (let i = 2; i < assertions.length; i++) {
       const a = assertions[i];
       timestampsAreClose(time, a.time);
+      expect(a.entering).toBeTruthy();
+      expect(a.isIntersecting).toBeTruthy();
     }
   });
 


### PR DESCRIPTION
Add the `threshold` field to `SpanielObserverEntry` so that entries denote parameters of the threshold that was crossed