### PR TITLE
Add exports to v2-release

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -1,7 +1,7 @@
 /*
-Copyright 2017 LinkedIn Corp. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Copyright 2017 LinkedIn Corp. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 
 var Funnel = require('broccoli-funnel');

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "spaniel",
   "version": "2.9.3",
   "description": "LinkedIn's viewport tracking library",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "main": "exports/spaniel.js",
   "scripts": {
     "test": "tsc && yarn run build && yarn test:playwright && testem ci && node test/headless/run",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spaniel",
-  "version": "2.9.3",
+  "version": "2.10.0",
   "description": "LinkedIn's viewport tracking library",
   "license": "Apache-2.0",
   "main": "exports/spaniel.js",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,13 @@
     "CHANGELOG.md",
     ".travis.yml"
   ],
+  "exports": {
+    ".": {
+      "default": "./exports/spaniel.js",
+      "types": "./exports/index.d.ts"
+    }
+  },
+  "types": "exports/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/linkedin/spaniel"
@@ -41,7 +48,6 @@
   },
   "homepage": "https://github.com/linkedin/spaniel",
   "module": "exports/index.js",
-  "typings": "exports/index.d.ts",
   "devDependencies": {
     "@babel/core": "^7.2.2",
     "@babel/preset-env": "^7.2.2",


### PR DESCRIPTION
## Summary
Add type exports. Also swapped `typings` field for `types` since thats what listed in the [Node docs](https://nodejs.org/api/packages.html#community-conditions-definitions)

## Other random fixes:
* fix license string
* remove incorrect line terminators

### Testing Done
`$ tsc` ✅ 
linked package into consuming app, types worked