### PR TITLE
fix the export module order

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "exports": {
     ".": {
-      "types": "./exports/index.d.ts"
+      "types": "./exports/index.d.ts",
       "default": "./exports/spaniel.js"
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spaniel",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "LinkedIn's viewport tracking library",
   "license": "Apache-2.0",
   "main": "exports/spaniel.js",
@@ -30,8 +30,8 @@
   ],
   "exports": {
     ".": {
-      "default": "./exports/spaniel.js",
       "types": "./exports/index.d.ts"
+      "default": "./exports/spaniel.js"
     }
   },
   "types": "exports/index.d.ts",


### PR DESCRIPTION
Fix a webpack building error
```
 "Module not found: Error: Default condition should be last one"
```

Reference: https://stackoverflow.com/questions/76127288/module-not-found-error-default-condition-should-be-last-one 

Verified locally.